### PR TITLE
Remove unnecessary genericism and generic constraints.

### DIFF
--- a/Sources/CodableStructuredHeaders/Decoder/BareInnerListDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/BareInnerListDecoder.swift
@@ -14,14 +14,14 @@
 import Foundation
 import StructuredHeaders
 
-struct BareInnerListDecoder<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
-    private var list: BareInnerList<BaseData.SubSequence>
+struct BareInnerListDecoder<BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
+    private var list: BareInnerList
 
     private var currentOffset: Int
 
     private var decoder: _StructuredFieldDecoder<BaseData>
 
-    init(_ list: BareInnerList<BaseData.SubSequence>, decoder: _StructuredFieldDecoder<BaseData>) {
+    init(_ list: BareInnerList, decoder: _StructuredFieldDecoder<BaseData>) {
         self.list = list
         self.currentOffset = 0
         self.decoder = decoder

--- a/Sources/CodableStructuredHeaders/Decoder/BareItemDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/BareItemDecoder.swift
@@ -14,12 +14,12 @@
 import Foundation
 import StructuredHeaders
 
-struct BareItemDecoder<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence == BaseData, BaseData: Hashable {
-    private var item: BareItem<BaseData>
+struct BareItemDecoder {
+    private var item: BareItem
 
     private var _codingPath: [_StructuredHeaderCodingKey]
 
-    init(_ item: BareItem<BaseData>, codingPath: [_StructuredHeaderCodingKey]) {
+    init(_ item: BareItem, codingPath: [_StructuredHeaderCodingKey]) {
         self.item = item
         self._codingPath = codingPath
     }
@@ -102,7 +102,7 @@ extension BareItemDecoder: SingleValueDecodingContainer {
             throw StructuredHeaderError.invalidTypeForItem
         }
 
-        guard let decoded = Data(base64Encoded: Data(data)) else {
+        guard let decoded = Data(base64Encoded: data) else {
             throw StructuredHeaderError.invalidByteSequence
         }
 

--- a/Sources/CodableStructuredHeaders/Decoder/DictionaryKeyedContainer.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/DictionaryKeyedContainer.swift
@@ -14,12 +14,12 @@
 import Foundation
 import StructuredHeaders
 
-struct DictionaryKeyedContainer<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
-    private var dictionary: OrderedMap<String, ItemOrInnerList<BaseData.SubSequence>>
+struct DictionaryKeyedContainer<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
+    private var dictionary: OrderedMap<String, ItemOrInnerList>
 
     private var decoder: _StructuredFieldDecoder<BaseData>
 
-    init(_ dictionary: OrderedMap<String, ItemOrInnerList<BaseData.SubSequence>>, decoder: _StructuredFieldDecoder<BaseData>) {
+    init(_ dictionary: OrderedMap<String, ItemOrInnerList>, decoder: _StructuredFieldDecoder<BaseData>) {
         self.dictionary = dictionary
         self.decoder = decoder
     }

--- a/Sources/CodableStructuredHeaders/Decoder/KeyedInnerListDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/KeyedInnerListDecoder.swift
@@ -19,12 +19,12 @@ private let keyedInnerListDecoderSupportedKeys = ["items", "parameters"]
 /// Used when someone has requested a keyed decoder for a property of inner list type.
 ///
 /// There are only two valid keys for this: "items" and "parameters".
-struct KeyedInnerListDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
-    private var innerList: InnerList<BaseData.SubSequence>
+struct KeyedInnerListDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
+    private var innerList: InnerList
 
     private var decoder: _StructuredFieldDecoder<BaseData>
 
-    init(_ innerList: InnerList<BaseData.SubSequence>, decoder: _StructuredFieldDecoder<BaseData>) {
+    init(_ innerList: InnerList, decoder: _StructuredFieldDecoder<BaseData>) {
         self.innerList = innerList
         self.decoder = decoder
     }

--- a/Sources/CodableStructuredHeaders/Decoder/KeyedItemDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/KeyedItemDecoder.swift
@@ -19,12 +19,12 @@ private let keyedItemDecoderSupportedKeys = ["item", "parameters"]
 /// Used when someone has requested a keyed decoder for a property of item type.
 ///
 /// There are only two valid keys for this: "item" and "parameters".
-struct KeyedItemDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
-    private var item: Item<BaseData.SubSequence>
+struct KeyedItemDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
+    private var item: Item
 
     private var decoder: _StructuredFieldDecoder<BaseData>
 
-    init(_ item: Item<BaseData.SubSequence>, decoder: _StructuredFieldDecoder<BaseData>) {
+    init(_ item: Item, decoder: _StructuredFieldDecoder<BaseData>) {
         self.item = item
         self.decoder = decoder
     }

--- a/Sources/CodableStructuredHeaders/Decoder/KeyedTopLevelListDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/KeyedTopLevelListDecoder.swift
@@ -19,12 +19,12 @@ private let keyedTopLevelListDecoderSupportedKeys = ["items"]
 /// Used when someone has requested a keyed decoder for a property of list type.
 ///
 /// There is only one valid key for this: "items".
-struct KeyedTopLevelListDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
-    private var list: [ItemOrInnerList<BaseData.SubSequence>]
+struct KeyedTopLevelListDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
+    private var list: [ItemOrInnerList]
 
     private var decoder: _StructuredFieldDecoder<BaseData>
-
-    init(_ list: [ItemOrInnerList<BaseData.SubSequence>], decoder: _StructuredFieldDecoder<BaseData>) {
+    
+    init(_ list: [ItemOrInnerList], decoder: _StructuredFieldDecoder<BaseData>) {
         self.list = list
         self.decoder = decoder
     }

--- a/Sources/CodableStructuredHeaders/Decoder/ParametersDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/ParametersDecoder.swift
@@ -14,12 +14,12 @@
 import Foundation
 import StructuredHeaders
 
-struct ParametersDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
-    private var parameters: OrderedMap<String, BareItem<BaseData.SubSequence>>
+struct ParametersDecoder<Key: CodingKey, BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
+    private var parameters: OrderedMap<String, BareItem>
 
     private var decoder: _StructuredFieldDecoder<BaseData>
 
-    init(_ parameters: OrderedMap<String, BareItem<BaseData.SubSequence>>, decoder: _StructuredFieldDecoder<BaseData>) {
+    init(_ parameters: OrderedMap<String, BareItem>, decoder: _StructuredFieldDecoder<BaseData>) {
         self.parameters = parameters
         self.decoder = decoder
     }

--- a/Sources/CodableStructuredHeaders/Decoder/StructuredFieldDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/StructuredFieldDecoder.swift
@@ -46,7 +46,7 @@ extension StructuredFieldDecoder {
     ///     - data: The bytes of the structured header field.
     /// - throws: If the header field could not be parsed, or could not be decoded.
     /// - returns: An object of type `StructuredField`.
-    public func decode<StructuredField: StructuredHeaderField, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
+    public func decode<StructuredField: StructuredHeaderField, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8 {
         switch StructuredField.structuredFieldType {
         case .item:
             return try self.decodeItemField(from: data)
@@ -64,7 +64,7 @@ extension StructuredFieldDecoder {
     ///     - data: The bytes of the structured header field.
     /// - throws: If the header field could not be parsed, or could not be decoded.
     /// - returns: An object of type `StructuredField`.
-    private func decodeDictionaryField<StructuredField: Decodable, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
+    private func decodeDictionaryField<StructuredField: Decodable, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8 {
         let parser = StructuredFieldParser(data)
         let decoder = _StructuredFieldDecoder(parser, keyDecodingStrategy: self.keyDecodingStrategy)
         try decoder.parseDictionaryField()
@@ -78,7 +78,7 @@ extension StructuredFieldDecoder {
     ///     - data: The bytes of the structured header field.
     /// - throws: If the header field could not be parsed, or could not be decoded.
     /// - returns: An object of type `StructuredField`.
-    private func decodeListField<StructuredField: Decodable, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
+    private func decodeListField<StructuredField: Decodable, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8 {
         let parser = StructuredFieldParser(data)
         let decoder = _StructuredFieldDecoder(parser, keyDecodingStrategy: self.keyDecodingStrategy)
         try decoder.parseListField()
@@ -92,7 +92,7 @@ extension StructuredFieldDecoder {
     ///     - data: The bytes of the structured header field.
     /// - throws: If the header field could not be parsed, or could not be decoded.
     /// - returns: An object of type `StructuredField`.
-    private func decodeItemField<StructuredField: Decodable, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
+    private func decodeItemField<StructuredField: Decodable, BaseData: RandomAccessCollection>(_ type: StructuredField.Type = StructuredField.self, from data: BaseData) throws -> StructuredField where BaseData.Element == UInt8 {
         let parser = StructuredFieldParser(data)
         let decoder = _StructuredFieldDecoder(parser, keyDecodingStrategy: self.keyDecodingStrategy)
         try decoder.parseItemField()
@@ -111,7 +111,7 @@ extension StructuredFieldDecoder {
     }
 }
 
-class _StructuredFieldDecoder<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
+class _StructuredFieldDecoder<BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
     private var parser: StructuredFieldParser<BaseData>
 
     // For now we use a stack here because the CoW operations on Array would suck. Ideally I'd just have us decode
@@ -220,13 +220,13 @@ extension _StructuredFieldDecoder: Decoder {
 extension _StructuredFieldDecoder {
     /// The basic elements that make up a Structured Header
     fileprivate enum Element {
-        case dictionary(OrderedMap<String, ItemOrInnerList<BaseData.SubSequence>>)
-        case list([ItemOrInnerList<BaseData.SubSequence>])
-        case item(Item<BaseData.SubSequence>)
-        case innerList(InnerList<BaseData.SubSequence>)
-        case bareItem(BareItem<BaseData.SubSequence>)
-        case bareInnerList(BareInnerList<BaseData.SubSequence>)
-        case parameters(OrderedMap<String, BareItem<BaseData.SubSequence>>)
+        case dictionary(OrderedMap<String, ItemOrInnerList>)
+        case list([ItemOrInnerList])
+        case item(Item)
+        case innerList(InnerList)
+        case bareItem(BareItem)
+        case bareInnerList(BareInnerList)
+        case parameters(OrderedMap<String, BareItem>)
 
         func innerElement(for key: _StructuredHeaderCodingKey) throws -> Element {
             switch self {

--- a/Sources/CodableStructuredHeaders/Decoder/TopLevelListDecoder.swift
+++ b/Sources/CodableStructuredHeaders/Decoder/TopLevelListDecoder.swift
@@ -14,14 +14,14 @@
 import Foundation
 import StructuredHeaders
 
-struct TopLevelListDecoder<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
-    private var list: [ItemOrInnerList<BaseData.SubSequence>]
+struct TopLevelListDecoder<BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
+    private var list: [ItemOrInnerList]
 
     private var currentOffset: Int
 
     private var decoder: _StructuredFieldDecoder<BaseData>
 
-    init(_ list: [ItemOrInnerList<BaseData.SubSequence>], decoder: _StructuredFieldDecoder<BaseData>) {
+    init(_ list: [ItemOrInnerList], decoder: _StructuredFieldDecoder<BaseData>) {
         self.list = list
         self.currentOffset = 0
         self.decoder = decoder

--- a/Sources/StructuredHeaders/ComponentTypes.swift
+++ b/Sources/StructuredHeaders/ComponentTypes.swift
@@ -21,9 +21,9 @@
 
 /// `ItemOrInnerList` represents the values in a structured header dictionary, or the
 /// entries in a structured header list.
-public enum ItemOrInnerList<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence == BaseData, BaseData: Hashable {
-    case item(Item<BaseData>)
-    case innerList(InnerList<BaseData>)
+public enum ItemOrInnerList {
+    case item(Item)
+    case innerList(InnerList)
 }
 
 extension ItemOrInnerList: Hashable {}
@@ -32,7 +32,7 @@ extension ItemOrInnerList: Hashable {}
 
 /// `BareItem` is a representation of the base data types at the bottom of a structured
 /// header field. These types are not parameterised: they are raw data.
-public enum BareItem<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence == BaseData, BaseData: Hashable {
+public enum BareItem {
     /// A boolean item.
     case bool(Bool)
 
@@ -47,7 +47,7 @@ public enum BareItem<BaseData: RandomAccessCollection> where BaseData.Element ==
 
     /// A byte sequence. This case must contain base64-encoded data, as
     /// `StructuredHeaders` does not do base64 encoding or decoding.
-    case undecodedByteSequence(BaseData)
+    case undecodedByteSequence(String)
 
     /// A token item.
     case token(String)
@@ -87,14 +87,14 @@ extension BareItem: Hashable {}
 
 /// `Item` represents a structured header field item: a combination of a `bareItem`
 /// and some parameters.
-public struct Item<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence == BaseData, BaseData: Hashable {
+public struct Item {
     /// The `BareItem` that this `Item` contains.
-    public var bareItem: BareItem<BaseData>
+    public var bareItem: BareItem
 
     /// The parameters associated with `bareItem`
-    public var parameters: OrderedMap<String, BareItem<BaseData>>
+    public var parameters: OrderedMap<String, BareItem>
 
-    public init(bareItem: BareItem<BaseData>, parameters: OrderedMap<String, BareItem<BaseData>>) {
+    public init(bareItem: BareItem, parameters: OrderedMap<String, BareItem>) {
         self.bareItem = bareItem
         self.parameters = parameters
     }
@@ -106,20 +106,20 @@ extension Item: Hashable {}
 
 /// A `BareInnerList` represents the items contained within an `InnerList`, without
 /// the associated parameters.
-public struct BareInnerList<BaseData: RandomAccessCollection>: Hashable where BaseData.Element == UInt8, BaseData.SubSequence == BaseData, BaseData: Hashable {
-    private var items: [Item<BaseData>]
+public struct BareInnerList: Hashable {
+    private var items: [Item]
 
     public init() {
         self.items = []
     }
 
-    public mutating func append(_ item: Item<BaseData>) {
+    public mutating func append(_ item: Item) {
         self.items.append(item)
     }
 }
 
 extension BareInnerList: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Item<BaseData>...) {
+    public init(arrayLiteral elements: Item...) {
         self.items = elements
     }
 }
@@ -127,9 +127,9 @@ extension BareInnerList: ExpressibleByArrayLiteral {
 // TODO: RangeReplaceableCollection I guess
 extension BareInnerList: RandomAccessCollection, MutableCollection {
     public struct Index {
-        fileprivate var baseIndex: Array<Item<BaseData>>.Index
+        fileprivate var baseIndex: Array<Item>.Index
 
-        init(_ baseIndex: Array<Item<BaseData>>.Index) {
+        init(_ baseIndex: Array<Item>.Index) {
             self.baseIndex = baseIndex
         }
     }
@@ -158,7 +158,7 @@ extension BareInnerList: RandomAccessCollection, MutableCollection {
         Index(self.items.index(i.baseIndex, offsetBy: offset))
     }
 
-    public subscript(index: Index) -> Item<BaseData> {
+    public subscript(index: Index) -> Item {
         get {
             self.items[index.baseIndex]
         }
@@ -179,14 +179,14 @@ extension BareInnerList.Index: Comparable {
 // MARK: - InnerList
 
 /// An `InnerList` is a list of items, with some associated parameters.
-public struct InnerList<BaseData: RandomAccessCollection>: Hashable where BaseData.Element == UInt8, BaseData.SubSequence == BaseData, BaseData: Hashable {
+public struct InnerList: Hashable {
     /// The items contained within this inner list.
-    public var bareInnerList: BareInnerList<BaseData>
+    public var bareInnerList: BareInnerList
 
     /// The parameters associated with the `bareInnerList`.
-    public var parameters: OrderedMap<String, BareItem<BaseData>>
+    public var parameters: OrderedMap<String, BareItem>
 
-    public init(bareInnerList: BareInnerList<BaseData>, parameters: OrderedMap<String, BareItem<BaseData>>) {
+    public init(bareInnerList: BareInnerList, parameters: OrderedMap<String, BareItem>) {
         self.bareInnerList = bareInnerList
         self.parameters = parameters
     }

--- a/Sources/StructuredHeaders/FieldParser.swift
+++ b/Sources/StructuredHeaders/FieldParser.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A `StructuredFieldParser` is the basic parsing object for structured header fields.
-public struct StructuredFieldParser<BaseData: RandomAccessCollection> where BaseData.Element == UInt8, BaseData.SubSequence: Hashable {
+public struct StructuredFieldParser<BaseData: RandomAccessCollection> where BaseData.Element == UInt8 {
     // Right now I'm on the fence about whether this should be generic. It's convenient,
     // and makes it really easy for us to express the parsing over a wide range of data types.
     // But it risks code size in a really nasty way! We should validate that we don't pay too
@@ -27,11 +27,11 @@ public struct StructuredFieldParser<BaseData: RandomAccessCollection> where Base
 
 extension StructuredFieldParser {
     // Helper typealiases to avoid the explosion of generic parameters
-    public typealias BareItem = StructuredHeaders.BareItem<BaseData.SubSequence>
-    public typealias Item = StructuredHeaders.Item<BaseData.SubSequence>
-    public typealias BareInnerList = StructuredHeaders.BareInnerList<BaseData.SubSequence>
-    public typealias InnerList = StructuredHeaders.InnerList<BaseData.SubSequence>
-    public typealias ItemOrInnerList = StructuredHeaders.ItemOrInnerList<BaseData.SubSequence>
+    public typealias BareItem = StructuredHeaders.BareItem
+    public typealias Item = StructuredHeaders.Item
+    public typealias BareInnerList = StructuredHeaders.BareInnerList
+    public typealias InnerList = StructuredHeaders.InnerList
+    public typealias ItemOrInnerList = StructuredHeaders.ItemOrInnerList
     public typealias Key = String
 
     /// Parse the HTTP structured field as a list.
@@ -389,7 +389,7 @@ extension StructuredFieldParser {
                 self.underlyingData.formIndex(after: &index)
                 self.underlyingData = self.underlyingData[index...]
 
-                return .undecodedByteSequence(consumedSlice)
+                return .undecodedByteSequence(String(decoding: consumedSlice, as: UTF8.self))
 
             case asciiCapitals, asciiLowercases, asciiDigits, asciiPlus, asciiSlash, asciiEqual:
                 // All valid characters for Base64 here.

--- a/Sources/sh-parser/main.swift
+++ b/Sources/sh-parser/main.swift
@@ -58,9 +58,9 @@ extension Flags {
 }
 
 enum Header {
-    case dictionary(OrderedMap<String, ItemOrInnerList<Data>>)
-    case list([ItemOrInnerList<Data>])
-    case item(Item<Data>)
+    case dictionary(OrderedMap<String, ItemOrInnerList>)
+    case list([ItemOrInnerList])
+    case item(Item)
 
     func prettyPrint() {
         switch self {
@@ -77,7 +77,7 @@ enum Header {
     }
 }
 
-extension Array where Element == ItemOrInnerList<Data> {
+extension Array where Element == ItemOrInnerList {
     func prettyPrint(depth: Int) {
         let tabs = String(repeating: "\t", count: depth)
         for (offset, element) in self.enumerated() {
@@ -87,7 +87,7 @@ extension Array where Element == ItemOrInnerList<Data> {
     }
 }
 
-extension OrderedMap where Key == String, Value == ItemOrInnerList<Data> {
+extension OrderedMap where Key == String, Value == ItemOrInnerList {
     func prettyPrint(depth: Int) {
         let tabs = String(repeating: "\t", count: depth)
         for (key, value) in self {
@@ -97,7 +97,7 @@ extension OrderedMap where Key == String, Value == ItemOrInnerList<Data> {
     }
 }
 
-extension OrderedMap where Key == String, Value == BareItem<Data> {
+extension OrderedMap where Key == String, Value == BareItem {
     func prettyPrint(depth: Int) {
         let tabs = String(repeating: "\t", count: depth)
 
@@ -107,7 +107,7 @@ extension OrderedMap where Key == String, Value == BareItem<Data> {
     }
 }
 
-extension ItemOrInnerList where BaseData == Data {
+extension ItemOrInnerList {
     func prettyPrint(depth: Int) {
         switch self {
         case .item(let item):
@@ -118,7 +118,7 @@ extension ItemOrInnerList where BaseData == Data {
     }
 }
 
-extension Item where BaseData == Data {
+extension Item {
     func prettyPrint(depth: Int) {
         let tabs = String(repeating: "\t", count: depth)
 
@@ -128,7 +128,7 @@ extension Item where BaseData == Data {
     }
 }
 
-extension InnerList where BaseData == Data {
+extension InnerList {
     func prettyPrint(depth: Int) {
         let tabs = String(repeating: "\t", count: depth)
 
@@ -139,7 +139,7 @@ extension InnerList where BaseData == Data {
     }
 }
 
-extension BareInnerList where BaseData == Data {
+extension BareInnerList {
     func prettyPrint(depth: Int) {
         let tabs = String(repeating: "\t", count: depth)
         for (offset, element) in self.enumerated() {
@@ -149,7 +149,7 @@ extension BareInnerList where BaseData == Data {
     }
 }
 
-extension BareItem where BaseData == Data {
+extension BareItem {
     func prettyFormat() -> String {
         switch self {
         case .bool(let bool):


### PR DESCRIPTION
Motivation:

Early on in the design of Structured Headers I made a conscious effort
to try to avoid transforming types in the low-level API. This design was
built on the assumption that strings, tokens, and some other data types
could be built entirely as slices of the backing data.

Unfortunately, this isn't true: because of the need to escape chars in
Strings, it became necessary to start using more complex types in Item.
Eventually, we ended up in a place where the only field in Item that
actually stored backing data was `.undecodedByteSequence`.

This field forced almost the entire set of types in the
StructuredHeaders module to be generic, just for the sake of carrying
this one slice type around. This prevented powerful optimisations,
bloated code size, and forced additional unnecessary heap allocations.
It also forced us to constrain the types used in the parser to those
where the subsequence type was Hashable, which excluded some really
important types (like `String.UTF8View`).

Fundamentally, this genericism was hurting more than it helped at this
point, so I bit the bullet and replaced the slice type with `String` for
`undecodedByteSequence`. This led to a huge cascading removal of generic
type parameters for a wide range of types, as well as the removal of the
"must have hashable subsequence" constraints on the parser data type.
This lifts an enormous amount of complexity out of the module at the
extremely minor cost of forcing an allocation whenever we have a lot of
undecoded binary data: not a huge cost, in my view, and well worth what
we got back in return.

Modifications:

- Remove generic type parameter in BaseItem.
- Remove generic types everywhere else.
- Remove hashable constraint.

Result:

Better, faster, simpler code.