### PR TITLE
Add docker-based test harness.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+ARG swift_version=5.2
+ARG ubuntu_version=bionic
+ARG base_image=swift:$swift_version-$ubuntu_version
+FROM $base_image
+# needed to do again after FROM due to docker limitation
+ARG swift_version
+ARG ubuntu_version
+
+# set as UTF-8
+RUN apt-get update && apt-get install -y locales locales-all
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# dependencies
+RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq # used by integration tests
+
+# ruby and jazzy for docs generation
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
+# jazzy no longer works on xenial as ruby is too old.
+RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy --no-ri --no-rdoc ; fi
+
+# tools
+RUN mkdir -p $HOME/.tools
+RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
+
+# swiftformat (until part of the toolchain)
+
+ARG swiftformat_version=0.40.12
+RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
+RUN cd $HOME/.tools/swift-format && swift build -c release
+RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-http-structured-headers:16.04-5.2
+    build:
+      args:
+        ubuntu_version: "xenial"
+        swift_version: "5.2"
+
+  unit-tests:
+    image: swift-http-structured-headers:16.04-5.2
+
+  test:
+    image: swift-http-structured-headers:16.04-5.2
+    environment:
+      - SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-http-structured-headers:16.04-5.2

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-http-structured-headers:18.04-5.3
+    build:
+      args:
+        ubuntu_version: "bionic"
+        swift_version: "5.3"
+
+  unit-tests:
+    image: swift-http-structured-headers:18.04-5.3
+
+  test:
+    image: swift-http-structured-headers:18.04-5.3
+    environment:
+      - SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-http-structured-headers:18.04-5.3
+

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,42 @@
+# this file is not designed to be run directly
+# instead, use the docker-compose.<os>.<swift> files
+# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.1604.41.yaml run test
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-http-structured-headers:default
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  common: &common
+    image: swift-http-structured-headers:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ..:/code:z
+    working_dir: /code
+    cap_drop:
+      - CAP_NET_RAW
+      - CAP_NET_BIND_SERVICE
+
+  sanity:
+    <<: *common
+    command: /bin/bash -xcl "./scripts/sanity.sh"
+
+  unit-tests:
+    <<: *common
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors"
+
+  test:
+    <<: *common
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+
+
+  # util
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash


### PR DESCRIPTION
For testing we like to use docker to manage our Linux configurations.
This patch adds that support for helpful CI management.