### PR TITLE
Update for open-source Decimal fixes

### DIFF
--- a/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
@@ -116,7 +116,7 @@ extension BareItemDecoder: SingleValueDecodingContainer {
 
         return Decimal(sign: pseudoDecimal.mantissa > 0 ? .plus : .minus,
                        exponent: Int(pseudoDecimal.exponent),
-                       significand: Decimal(pseudoDecimal.mantissa))
+                       significand: Decimal(pseudoDecimal.mantissa.magnitude))
     }
 
     func decodeNil() -> Bool {

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -281,12 +281,12 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
     }
 
     func encode(_ data: Decimal) throws {
-        let significand = (data.significand as NSNumber).intValue // Yes, really.
+        let significand = (data.significand.magnitude as NSNumber).intValue // Yes, really.
         guard let exponent = Int8(exactly: data.exponent) else {
             throw StructuredHeaderError.invalidIntegerOrDecimal
         }
 
-        let pd = PseudoDecimal(mantissa: significand, exponent: Int(exponent))
+        let pd = PseudoDecimal(mantissa: significand * (data.isSignMinus ? -1 : 1), exponent: Int(exponent))
         try self.currentStackEntry.storage.insertBareItem(.decimal(pd))
     }
 

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -443,7 +443,7 @@ extension _StructuredFieldEncoder {
             throw StructuredHeaderError.invalidIntegerOrDecimal
         }
 
-        let pd = PseudoDecimal(mantissa: significand * (data.isSignMinus ? -1 : 1), exponent: Int(exponent))
+        let pd = PseudoDecimal(mantissa: significand * (value.isSignMinus ? -1 : 1), exponent: Int(exponent))
         try self.currentStackEntry.storage.appendBareItem(.decimal(pd))
     }
 
@@ -610,7 +610,7 @@ extension _StructuredFieldEncoder {
             throw StructuredHeaderError.invalidIntegerOrDecimal
         }
 
-        let pd = PseudoDecimal(mantissa: significand * (data.isSignMinus ? -1 : 1), exponent: Int(exponent))
+        let pd = PseudoDecimal(mantissa: significand * (value.isSignMinus ? -1 : 1), exponent: Int(exponent))
         try self.currentStackEntry.storage.insertBareItem(.decimal(pd), atKey: key)
     }
 

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -438,12 +438,12 @@ extension _StructuredFieldEncoder {
     }
 
     func append(_ value: Decimal) throws {
-        let significand = (value.significand as NSNumber).intValue // Yes, really.
+        let significand = (value.significand.magnitude as NSNumber).intValue // Yes, really.
         guard let exponent = Int8(exactly: value.exponent) else {
             throw StructuredHeaderError.invalidIntegerOrDecimal
         }
 
-        let pd = PseudoDecimal(mantissa: significand, exponent: Int(exponent))
+        let pd = PseudoDecimal(mantissa: significand * (data.isSignMinus ? -1 : 1), exponent: Int(exponent))
         try self.currentStackEntry.storage.appendBareItem(.decimal(pd))
     }
 
@@ -605,12 +605,12 @@ extension _StructuredFieldEncoder {
     }
 
     func encode(_ value: Decimal, forKey key: String) throws {
-        let significand = (value.significand as NSNumber).intValue // Yes, really.
+        let significand = (value.significand.magnitude as NSNumber).intValue // Yes, really.
         guard let exponent = Int8(exactly: value.exponent) else {
             throw StructuredHeaderError.invalidIntegerOrDecimal
         }
 
-        let pd = PseudoDecimal(mantissa: significand, exponent: Int(exponent))
+        let pd = PseudoDecimal(mantissa: significand * (data.isSignMinus ? -1 : 1), exponent: Int(exponent))
         try self.currentStackEntry.storage.insertBareItem(.decimal(pd), atKey: key)
     }
 


### PR DESCRIPTION
These are minimal changes to ensure cross-platform and future-proof usage of `Foundation.Decimal` APIs that have incorporated various fixes on Linux that may or may not be incorporated in future Apple releases also.

In brief, we'll always take the magnitude (absolute value) of the value that's returned from `Decimal.significand` and always in turn provide a positive significand to `Decimal.init(sign:exponent:significand:)`.

Works around [SR-15132](https://bugs.swift.org/browse/SR-15132).