### PR TITLE
Move CI to 5.6 main and add 5.7

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -6,8 +6,8 @@ services:
     image: swift-http-structured-headers:20.04-5.6
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.6-focal"
         ubuntu_version: "focal"
+        swift_version: "5.6"
 
   unit-tests:
     image: swift-http-structured-headers:20.04-5.6

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -7,7 +7,6 @@ services:
     build:
       args:
         base_image: "swiftlang/swift:nightly-main-focal"
-        ubuntu_version: "focal"
 
   unit-tests:
     image: swift-http-structured-headers:20.04-5.7

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-http-structured-headers:20.04-5.7
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-main-focal"
+        ubuntu_version: "focal"
+
+  unit-tests:
+    image: swift-http-structured-headers:20.04-5.7
+
+  test:
+    image: swift-http-structured-headers:20.04-5.7
+
+  shell:
+    image: swift-http-structured-headers:20.04-5.7
+


### PR DESCRIPTION
5.7 currently uses main, we'll update it when we get a branch for it.

@yim-lee @tomerd can we get the appropriate Jenkins updates as well?