### PR TITLE
Adopt Sendable

### DIFF
--- a/Sources/RawStructuredFieldValues/ComponentTypes.swift
+++ b/Sources/RawStructuredFieldValues/ComponentTypes.swift
@@ -21,7 +21,7 @@
 
 /// `ItemOrInnerList` represents the values in a structured header dictionary, or the
 /// entries in a structured header list.
-public enum ItemOrInnerList: _Sendable {
+public enum ItemOrInnerList: SHSendable {
     case item(Item)
     case innerList(InnerList)
 }
@@ -32,7 +32,7 @@ extension ItemOrInnerList: Hashable {}
 
 /// `BareItem` is a representation of the base data types at the bottom of a structured
 /// header field. These types are not parameterised: they are raw data.
-public enum BareItem: _Sendable {
+public enum BareItem: SHSendable {
     /// A boolean item.
     case bool(Bool)
 
@@ -87,7 +87,7 @@ extension BareItem: Hashable {}
 
 /// `Item` represents a structured header field item: a combination of a `bareItem`
 /// and some parameters.
-public struct Item: _Sendable {
+public struct Item: SHSendable {
     /// The `BareItem` that this `Item` contains.
     public var bareItem: BareItem
 
@@ -106,7 +106,7 @@ extension Item: Hashable {}
 
 /// A `BareInnerList` represents the items contained within an `InnerList`, without
 /// the associated parameters.
-public struct BareInnerList: Hashable, _Sendable {
+public struct BareInnerList: Hashable, SHSendable {
     private var items: [Item]
 
     public init() {
@@ -179,7 +179,7 @@ extension BareInnerList.Index: Comparable {
 // MARK: - InnerList
 
 /// An `InnerList` is a list of items, with some associated parameters.
-public struct InnerList: Hashable, _Sendable {
+public struct InnerList: Hashable, SHSendable {
     /// The items contained within this inner list.
     public var bareInnerList: BareInnerList
 

--- a/Sources/RawStructuredFieldValues/ComponentTypes.swift
+++ b/Sources/RawStructuredFieldValues/ComponentTypes.swift
@@ -21,7 +21,7 @@
 
 /// `ItemOrInnerList` represents the values in a structured header dictionary, or the
 /// entries in a structured header list.
-public enum ItemOrInnerList {
+public enum ItemOrInnerList: _Sendable {
     case item(Item)
     case innerList(InnerList)
 }
@@ -32,7 +32,7 @@ extension ItemOrInnerList: Hashable {}
 
 /// `BareItem` is a representation of the base data types at the bottom of a structured
 /// header field. These types are not parameterised: they are raw data.
-public enum BareItem {
+public enum BareItem: _Sendable {
     /// A boolean item.
     case bool(Bool)
 
@@ -87,7 +87,7 @@ extension BareItem: Hashable {}
 
 /// `Item` represents a structured header field item: a combination of a `bareItem`
 /// and some parameters.
-public struct Item {
+public struct Item: _Sendable {
     /// The `BareItem` that this `Item` contains.
     public var bareItem: BareItem
 
@@ -106,7 +106,7 @@ extension Item: Hashable {}
 
 /// A `BareInnerList` represents the items contained within an `InnerList`, without
 /// the associated parameters.
-public struct BareInnerList: Hashable {
+public struct BareInnerList: Hashable, _Sendable {
     private var items: [Item]
 
     public init() {
@@ -179,7 +179,7 @@ extension BareInnerList.Index: Comparable {
 // MARK: - InnerList
 
 /// An `InnerList` is a list of items, with some associated parameters.
-public struct InnerList: Hashable {
+public struct InnerList: Hashable, _Sendable {
     /// The items contained within this inner list.
     public var bareInnerList: BareInnerList
 

--- a/Sources/RawStructuredFieldValues/Errors.swift
+++ b/Sources/RawStructuredFieldValues/Errors.swift
@@ -15,7 +15,7 @@
 // MARK: - StructuredHeaderError
 
 /// Errors that may be encountered when working with structured headers.
-public struct StructuredHeaderError: Error, _Sendable {
+public struct StructuredHeaderError: Error, SHSendable {
     private enum _BaseError: Hashable {
         case invalidTrailingBytes
         case invalidInnerList

--- a/Sources/RawStructuredFieldValues/Errors.swift
+++ b/Sources/RawStructuredFieldValues/Errors.swift
@@ -15,7 +15,7 @@
 // MARK: - StructuredHeaderError
 
 /// Errors that may be encountered when working with structured headers.
-public struct StructuredHeaderError: Error {
+public struct StructuredHeaderError: Error, _Sendable {
     private enum _BaseError: Hashable {
         case invalidTrailingBytes
         case invalidInnerList

--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -25,9 +25,7 @@ public struct StructuredFieldValueParser<BaseData: RandomAccessCollection> where
     }
 }
 
-extension StructuredFieldValueParser: SHSendable where BaseData: SHSendable, BaseData.SubSequence: SHSendable {
-
-}
+extension StructuredFieldValueParser: SHSendable where BaseData: SHSendable, BaseData.SubSequence: SHSendable {}
 
 extension StructuredFieldValueParser {
     // Helper typealiases to avoid the explosion of generic parameters

--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -25,7 +25,7 @@ public struct StructuredFieldValueParser<BaseData: RandomAccessCollection> where
     }
 }
 
-extension StructuredFieldValueParser: _Sendable where BaseData: _Sendable, BaseData.SubSequence: _Sendable {
+extension StructuredFieldValueParser: SHSendable where BaseData: SHSendable, BaseData.SubSequence: SHSendable {
 
 }
 

--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -25,6 +25,10 @@ public struct StructuredFieldValueParser<BaseData: RandomAccessCollection> where
     }
 }
 
+extension StructuredFieldValueParser: _Sendable where BaseData: _Sendable, BaseData.SubSequence: _Sendable {
+
+}
+
 extension StructuredFieldValueParser {
     // Helper typealiases to avoid the explosion of generic parameters
     public typealias BareItem = RawStructuredFieldValues.BareItem

--- a/Sources/RawStructuredFieldValues/FieldSerializer.swift
+++ b/Sources/RawStructuredFieldValues/FieldSerializer.swift
@@ -15,7 +15,7 @@
 private let validIntegerRange = Int64(-999_999_999_999_999) ... Int64(999_999_999_999_999)
 
 /// A `StructuredFieldValueSerializer` is the basic parsing object for structured header field values.
-public struct StructuredFieldValueSerializer {
+public struct StructuredFieldValueSerializer: _Sendable {
     private var data: [UInt8]
 
     public init() {

--- a/Sources/RawStructuredFieldValues/FieldSerializer.swift
+++ b/Sources/RawStructuredFieldValues/FieldSerializer.swift
@@ -15,7 +15,7 @@
 private let validIntegerRange = Int64(-999_999_999_999_999) ... Int64(999_999_999_999_999)
 
 /// A `StructuredFieldValueSerializer` is the basic parsing object for structured header field values.
-public struct StructuredFieldValueSerializer: _Sendable {
+public struct StructuredFieldValueSerializer: SHSendable {
     private var data: [UInt8]
 
     public init() {

--- a/Sources/RawStructuredFieldValues/OrderedMap.swift
+++ b/Sources/RawStructuredFieldValues/OrderedMap.swift
@@ -23,7 +23,7 @@
 /// Note that this preserves _original_ insertion order: if you overwrite a key's value, the
 /// key does not move to "last". This is a specific requirement for Structured Headers and may
 /// harm the generality of this implementation.
-public struct OrderedMap<Key, Value> where Key: Hashable {
+public struct OrderedMap<Key, Value>: _Sendable where Key: Hashable {
     private var backing: [Entry]
 
     public init() {
@@ -70,7 +70,7 @@ extension OrderedMap {
 // MARK: - Collection conformances
 
 extension OrderedMap: RandomAccessCollection, MutableCollection {
-    public struct Index {
+    public struct Index: _Sendable {
         fileprivate var baseIndex: Array<(Key, Value)>.Index
 
         fileprivate init(_ baseIndex: Array<(Key, Value)>.Index) {

--- a/Sources/RawStructuredFieldValues/OrderedMap.swift
+++ b/Sources/RawStructuredFieldValues/OrderedMap.swift
@@ -23,7 +23,7 @@
 /// Note that this preserves _original_ insertion order: if you overwrite a key's value, the
 /// key does not move to "last". This is a specific requirement for Structured Headers and may
 /// harm the generality of this implementation.
-public struct OrderedMap<Key, Value>: SHSendable where Key: Hashable {
+public struct OrderedMap<Key, Value> where Key: Hashable {
     private var backing: [Entry]
 
     public init() {
@@ -66,6 +66,10 @@ extension OrderedMap {
         var value: Value
     }
 }
+
+extension OrderedMap: SHSendable where Key: SHSendable, Value: SHSendable {}
+
+extension OrderedMap.Entry: SHSendable where Key: SHSendable, Value: SHSendable {}
 
 // MARK: - Collection conformances
 

--- a/Sources/RawStructuredFieldValues/OrderedMap.swift
+++ b/Sources/RawStructuredFieldValues/OrderedMap.swift
@@ -23,7 +23,7 @@
 /// Note that this preserves _original_ insertion order: if you overwrite a key's value, the
 /// key does not move to "last". This is a specific requirement for Structured Headers and may
 /// harm the generality of this implementation.
-public struct OrderedMap<Key, Value>: _Sendable where Key: Hashable {
+public struct OrderedMap<Key, Value>: SHSendable where Key: Hashable {
     private var backing: [Entry]
 
     public init() {
@@ -70,7 +70,7 @@ extension OrderedMap {
 // MARK: - Collection conformances
 
 extension OrderedMap: RandomAccessCollection, MutableCollection {
-    public struct Index: _Sendable {
+    public struct Index: SHSendable {
         fileprivate var baseIndex: Array<(Key, Value)>.Index
 
         fileprivate init(_ baseIndex: Array<(Key, Value)>.Index) {

--- a/Sources/RawStructuredFieldValues/PseudoDecimal.swift
+++ b/Sources/RawStructuredFieldValues/PseudoDecimal.swift
@@ -34,7 +34,7 @@ import Glibc
 /// is 999,999,999,999,999. The exponent ranges from -3 to 0. Additionally, there may be no more than 12 decimal digits before
 /// the decimal place, so while the maximum value of the significand is 999,999,999,999,999, that is only acceptable if the
 /// exponent is -3.
-public struct PseudoDecimal: Hashable {
+public struct PseudoDecimal: Hashable, _Sendable {
     private var _mantissa: Int64
 
     private var _exponent: Int8

--- a/Sources/RawStructuredFieldValues/PseudoDecimal.swift
+++ b/Sources/RawStructuredFieldValues/PseudoDecimal.swift
@@ -34,7 +34,7 @@ import Glibc
 /// is 999,999,999,999,999. The exponent ranges from -3 to 0. Additionally, there may be no more than 12 decimal digits before
 /// the decimal place, so while the maximum value of the significand is 999,999,999,999,999, that is only acceptable if the
 /// exponent is -3.
-public struct PseudoDecimal: Hashable, _Sendable {
+public struct PseudoDecimal: Hashable, SHSendable {
     private var _mantissa: Int64
 
     private var _exponent: Int8

--- a/Sources/RawStructuredFieldValues/Sendable.swift
+++ b/Sources/RawStructuredFieldValues/Sendable.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=5.5) && canImport(_Concurrency)
-public typealias _Sendable = Sendable
+public typealias SHSendable = Sendable
 #else
-public typealias _Sendable = Any
+public typealias SHSendable = Any
 #endif

--- a/Sources/RawStructuredFieldValues/Sendable.swift
+++ b/Sources/RawStructuredFieldValues/Sendable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/RawStructuredFieldValues/Sendable.swift
+++ b/Sources/RawStructuredFieldValues/Sendable.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.5) && canImport(_Concurrency)
+public typealias _Sendable = Sendable
+#else
+public typealias _Sendable = Any
+#endif

--- a/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
@@ -16,7 +16,7 @@ import RawStructuredFieldValues
 
 /// A `StructuredFieldValueDecoder` allows decoding `Decodable` objects from a HTTP
 /// structured header field.
-public struct StructuredFieldValueDecoder {
+public struct StructuredFieldValueDecoder: _Sendable {
     /// A strategy that should be used to map coding keys to wire format keys.
     public var keyDecodingStrategy: KeyDecodingStrategy?
 
@@ -25,7 +25,7 @@ public struct StructuredFieldValueDecoder {
 
 extension StructuredFieldValueDecoder {
     /// A strategy that should be used to map coding keys to wire format keys.
-    public struct KeyDecodingStrategy: Hashable {
+    public struct KeyDecodingStrategy: Hashable, _Sendable {
         fileprivate enum Base: Hashable {
             case lowercase
         }

--- a/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
@@ -16,7 +16,7 @@ import RawStructuredFieldValues
 
 /// A `StructuredFieldValueDecoder` allows decoding `Decodable` objects from a HTTP
 /// structured header field.
-public struct StructuredFieldValueDecoder: _Sendable {
+public struct StructuredFieldValueDecoder: SHSendable {
     /// A strategy that should be used to map coding keys to wire format keys.
     public var keyDecodingStrategy: KeyDecodingStrategy?
 
@@ -25,7 +25,7 @@ public struct StructuredFieldValueDecoder: _Sendable {
 
 extension StructuredFieldValueDecoder {
     /// A strategy that should be used to map coding keys to wire format keys.
-    public struct KeyDecodingStrategy: Hashable, _Sendable {
+    public struct KeyDecodingStrategy: Hashable, SHSendable {
         fileprivate enum Base: Hashable {
             case lowercase
         }

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -16,7 +16,7 @@ import RawStructuredFieldValues
 
 /// A `StructuredFieldValueEncoder` allows encoding `Encodable` objects to the format of a HTTP
 /// structured header field.
-public struct StructuredFieldValueEncoder: _Sendable {
+public struct StructuredFieldValueEncoder: SHSendable {
     public var keyEncodingStrategy: KeyEncodingStrategy?
 
     public init() {}
@@ -24,7 +24,7 @@ public struct StructuredFieldValueEncoder: _Sendable {
 
 extension StructuredFieldValueEncoder {
     /// A strategy that should be used to map coding keys to wire format keys.
-    public struct KeyEncodingStrategy: Hashable, _Sendable {
+    public struct KeyEncodingStrategy: Hashable, SHSendable {
         fileprivate enum Base: Hashable {
             case lowercase
         }

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -16,7 +16,7 @@ import RawStructuredFieldValues
 
 /// A `StructuredFieldValueEncoder` allows encoding `Encodable` objects to the format of a HTTP
 /// structured header field.
-public struct StructuredFieldValueEncoder {
+public struct StructuredFieldValueEncoder: _Sendable {
     public var keyEncodingStrategy: KeyEncodingStrategy?
 
     public init() {}
@@ -24,7 +24,7 @@ public struct StructuredFieldValueEncoder {
 
 extension StructuredFieldValueEncoder {
     /// A strategy that should be used to map coding keys to wire format keys.
-    public struct KeyEncodingStrategy: Hashable {
+    public struct KeyEncodingStrategy: Hashable, _Sendable {
         fileprivate enum Base: Hashable {
             case lowercase
         }

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -17,7 +17,7 @@ set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed  -e 's/2020-2021/YEARS/' -e 's/202[01]/YEARS/'
+    sed  -e 's/202[01]-202[012]/YEARS/' -e 's/202[012]/YEARS/'
 }
 
 


### PR DESCRIPTION
Because we don't have a NIO dependency we don't have access to `NIOSendable`. To avoid ` lot of `#if`s throughout the code (making it neater and nicer/easier to read and maintain) I defined my own version, `_Sendable`. 