### PR TITLE
Use Docc for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 xcuserdata/
 .swiftpm/
+Package.resolved

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2020-2022 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -25,9 +25,6 @@ let package = Package(
             name: "RawStructuredFieldValues",
             targets: ["RawStructuredFieldValues"]
         ),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -25,9 +25,6 @@ let package = Package(
             name: "RawStructuredFieldValues",
             targets: ["RawStructuredFieldValues"]
         ),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(

--- a/Sources/RawStructuredFieldValues/ComponentTypes.swift
+++ b/Sources/RawStructuredFieldValues/ComponentTypes.swift
@@ -104,7 +104,7 @@ extension Item: Hashable {}
 
 // MARK: - BareInnerList
 
-/// A `BareInnerList` represents the items contained within an `InnerList`, without
+/// A `BareInnerList` represents the items contained within an ``InnerList``, without
 /// the associated parameters.
 public struct BareInnerList: Hashable, SHSendable {
     private var items: [Item]

--- a/Sources/RawStructuredFieldValues/Docs.docc/index.md
+++ b/Sources/RawStructuredFieldValues/Docs.docc/index.md
@@ -1,0 +1,92 @@
+# ``RawStructuredFieldValues``
+
+A Swift implementation of the HTTP Structured Header Field Value specification.
+
+Provides parsing and serialization facilities for structured header field values.
+
+## About Structured Header Field Values
+
+HTTP Structured Header Field Values are a HTTP extension recorded in [RFC 8941](https://www.rfc-editor.org/rfc/rfc8941.html). They provide a set of data types and algorithms for handling HTTP header field values in a consistent way, allowing a single parser and serializer to handle a wide range of header field values.
+
+## Swift HTTP Structured Header Field Values
+
+This package provides a parser and serializer that implement RFC 8941. They are entirely complete, able to handle all valid HTTP structured header field values.
+
+This package provides two top-level modules: `StructuredFieldValues` and `RawStructuredFieldValues`.
+
+This module, `RawStructuredFieldValues`, provides a low-level implementation of a serializer and parser. Both of these have been written to avoid using Foundation, making them suitable for a range of use-cases where Foundation is not available. They rely entirely on the Swift standard library and are implemented as generically as possible. One of the limitations due to the absence of Foundation is that this interface is not capable of performing Base64 encoding or decoding: users are free to bring whatever encoder and decoder they choose to use.
+
+This API is low-level, exposing the raw parse tree as the format for the serializer and parser. This allows high-performance and high-flexibility parsing and serialization, at the cost of being verbose and complex. Users are required to understand the structured header format and to operate the slightly awkward types, but maximal fidelity is retained and the performance overhead is low.
+
+The upper-level module, `StructuredFieldValues`, brings along the `Encoder` and `Decoder` and also adds a dependency on Foundation. This Foundation dependency is necessary to correctly handle the base64 formatting, as well as to provide a good natural container for binary data: `Data`. This interface is substantially friendlier and easier to work with, using Swift's `Codable` support to provide a great user experience.
+
+In most cases users should prefer to use `StructuredFieldValues` unless they know they need the performance advantages of `RawStructuredFieldValues`. The experience will be much better.
+
+## Working with Structured Header Field Values
+
+`RawStructuredFieldValues` has a powerful API for working with structured header field values.
+
+There are two core types: ``StructuredFieldValueParser`` and ``StructuredFieldValueSerializer``. Rather than work with high-level Swift objects, these two objects either produce or accept a Swift representation of the data tree for a given structured header field.
+
+This exposes the maximum amount of information about the header field. It allows users to handle situations where `Codable` cannot necessarily provide the relevant information, such in cases where dictionary ordering is semantic, or where it's necessary to control whether fields are tokens or strings more closely.
+
+These APIs also have lower overhead than the `StructuredFieldValues` APIs.
+
+The cost is that the APIs are substantially more verbose. As an example, let's consider the [HTTP Client Hints specification](https://www.rfc-editor.org/rfc/rfc8942.html). This defines the following new header field:
+
+```
+The Accept-CH response header field indicates server support for the hints indicated in its value.  Servers wishing to receive user agent information through Client Hints SHOULD add Accept-CH response header to their responses as early as possible.
+
+Accept-CH is a Structured Header. Its value MUST be an sf-list whose members are tokens. Its ABNF is:
+
+    Accept-CH = sf-list
+
+For example:
+
+    Accept-CH: Sec-CH-Example, Sec-CH-Example-2
+```
+
+To parse or serialize this in `RawStructuredFieldValues` would look like this:
+
+```swift
+let field = Array("Sec-CH-Example, Sec-CH-Example-2".utf8)
+var parser = StructuredFieldValueParser(field)
+let parsed = parser.parseListFieldValue()
+
+print(parsed)
+// [
+//     .item(Item(bareItem: .token("Sec-CH-Example"), parameters: [])),
+//     .item(Item(bareItem: .token("Sec-CH-Example-2"), parameters: [])),
+// ]
+
+var serializer = StructuredFieldValueSerializer()
+let serialized = serializer.writeListFieldValue(parsed)
+```
+
+Notice the substantially more verbose types involved in this operation. These types are highly generic, giving the opportunity for parsing and serializing that greatly reduces the runtime overhead. They also make it easier to distinguish between tokens and strings, and to observe the order of objects in dictionaries or parameters, which can be lost at the Codable level.
+
+In general, users should consider this API only when they are confident they need either the flexibility or the performance. This may be valuable for header fields that do not evolve often, or that are highly dynamic.
+
+## Topics
+
+### Representing Structured Field Values
+
+- ``InnerList``
+- ``BareInnerList``
+- ``Item``
+- ``BareItem``
+- ``ItemOrInnerList``
+
+### Helper Types
+
+- ``OrderedMap``
+- ``PseudoDecimal``
+
+### Parsing and Serializing
+
+- ``StructuredFieldValueParser``
+- ``StructuredFieldValueSerializer``
+
+### Errors
+
+- ``StructuredHeaderError``

--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -63,7 +63,7 @@ extension StructuredFieldValueParser {
     /// Parse the HTTP structured header field value as a dictionary.
     ///
     /// - throws: If the field value could not be parsed.
-    /// - returns: An `OrderedMap` corresponding to the entries in the dictionary.
+    /// - returns: An ``OrderedMap`` corresponding to the entries in the dictionary.
     public mutating func parseDictionaryFieldValue() throws -> OrderedMap<Key, ItemOrInnerList> {
         // Step one, strip leading spaces.
         self.underlyingData.stripLeadingSpaces()
@@ -85,7 +85,7 @@ extension StructuredFieldValueParser {
     /// Parse the HTTP structured header field value as an item.
     ///
     /// - throws: If the field value could not be parsed.
-    /// - returns: The `Item` in the field.
+    /// - returns: The ``Item`` in the field.
     public mutating func parseItemFieldValue() throws -> Item {
         // Step one, strip leading spaces.
         self.underlyingData.stripLeadingSpaces()

--- a/Sources/StructuredFieldValues/Docs.docc/index.md
+++ b/Sources/StructuredFieldValues/Docs.docc/index.md
@@ -1,0 +1,87 @@
+# ``StructuredFieldValues``
+
+A Swift implementation of the HTTP Structured Header Field Value specification.
+
+Provides parsing and serialization facilities for structured header field values, as well as implementations of `Encoder` and `Decoder` to allow using `Codable` data types as the payloads of HTTP structured header fields.
+
+## About Structured Header Field Values
+
+HTTP Structured Header Field Values are a HTTP extension recorded in [RFC 8941](https://www.rfc-editor.org/rfc/rfc8941.html). They provide a set of data types and algorithms for handling HTTP header field values in a consistent way, allowing a single parser and serializer to handle a wide range of header field values.
+
+## Swift HTTP Structured Header Field Values
+
+This package provides a parser and serializer that implement RFC 8941. They are entirely complete, able to handle all valid HTTP structured header field values. This package also provides `Encoder` and `Decoder` objects for working with Codable in Swift. This allows rapid prototyping and experimentation with HTTP structured header field values, as well as interaction with the wider Swift Codable community.
+
+This package provides two top-level modules: `StructuredFieldValues` and `RawStructuredFieldValues`.
+
+This module, `StructuredFieldValues`, use the related module `RawStructuredFieldValues` to implement `Encoder` and `Decoder`. This interface is friendly and easy to work with.
+
+Users who have performance problems with this solution or have specific representational needs should investigate `RawStructuredFieldValues`.
+
+## Working with Structured Header Field Values
+
+`StructuredFieldValues` has a simple, easy-to-use high-level API for working with structured header field values. To begin with, let's consider the [HTTP Client Hints specification](https://www.rfc-editor.org/rfc/rfc8942.html). This defines the following new header field:
+
+```
+The Accept-CH response header field indicates server support for the hints indicated in its value.  Servers wishing to receive user agent information through Client Hints SHOULD add Accept-CH response header to their responses as early as possible.
+
+Accept-CH is a Structured Header. Its value MUST be an sf-list whose members are tokens. Its ABNF is:
+
+    Accept-CH = sf-list
+
+For example:
+
+    Accept-CH: Sec-CH-Example, Sec-CH-Example-2
+```
+
+`swift-http-structured-headers` can parse and serialize this field very simply:
+
+```swift
+let field = Array("Sec-CH-Example, Sec-CH-Example-2".utf8)
+
+struct AcceptCH: StructuredFieldValue {
+    static let structuredFieldType: StructuredFieldType = .list
+    
+    var items: [String]
+}
+
+// Decoding
+let decoder = StructuredFieldValueDecoder()
+let parsed = try decoder.decode(AcceptCH.self, from: field)
+
+// Encoding
+let encoder = StructuredFieldValueEncoder()
+let serialized = try encoder.encode(AcceptCH(items: ["Sec-CH-Example", "Sec-CH-Example-2"]))
+```
+
+However, structured header field values can be substantially more complex. Structured header fields can make use of 4 containers and 6 base item types. The containers are:
+
+1. Dictionaries. These are top-level elements and associate token keys with values. The values may be items, or may be inner lists, and each value may also have parameters associated with them. `StructuredFieldValues` can model dictionaries as either Swift objects (where the property names are dictionary keys).
+2. Lists. These are top-level elements, providing a sequence of items or inner lists. Each item or inner list may have parameters associated with them. `StructuredFieldValues` models these as Swift objects with one key, `items`, that must be a collection of entries.
+3. Inner Lists. These are lists that may be sub-entries of a dictionary or a list. The list entries are items, which may have parameters associated with them: additionally, an inner list may have parameters associated with itself as well. `StructuredFieldValues` models these as either Swift `Array`s _or_, if it's important to extract parameters, as a two-field Swift `struct` where one field is called `items` and contains an `Array`, and other field is called `parameters` and contains a dictionary.
+4. Parameters. Parameters associated token keys with items without parameters. These are used to store metadata about objects within a field. `StructuredFieldValues` models these as either Swift objects (where the property names are the parameter keys) or as Swift dictionaries.
+
+The base types are:
+
+1. Booleans. `StructuredFieldValues` models these as Swift's `Bool` type.
+2. Integers. `StructuredFieldValues` models these as any fixed-width integer type.
+3. Decimals. `StructuredFieldValues` models these as any floating-point type, or as Foundation's `Decimal`.
+4. Tokens. `StructuredFieldValues` models these as Swift's `String` type, where the range of characters is restricted.
+5. Strings. `StructuredFieldValues` models these as Swift's `String` type.
+6. Binary data. `StructuredFieldValues` models this as Foundation's `Data` type.
+
+For any Structured Header Field Value Item, the item may either be represented directly by the appropriate type, or by a Swift struct with two properties: `item` and `parameters`. This latter mode is how parameters on a given item may be captured.
+
+The top-level Structured Header Field Value must identify what kind of header field it corresponds to by using ``StructuredFieldType``: `.item`, `.list`, or `.dictionary`. This is inherent in the type of the field and will be specified in the relevant field specification.
+
+## Topics
+
+### Declaring Codable Types
+
+- ``StructuredFieldValue``
+- ``StructuredFieldType``
+
+### Encoding and Decoding
+
+- ``StructuredFieldValueEncoder``
+- ``StructuredFieldValueDecoder``

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the SwiftNIO open source project
 ##
-## Copyright (c) 2020-2021 Apple Inc. and the SwiftNIO project authors
+## Copyright (c) 2020-2022 Apple Inc. and the SwiftNIO project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -60,7 +60,7 @@ for language in swift-or-c bash dtrace; do
   matching_files=( -name '*' )
   case "$language" in
       swift-or-c)
-        exceptions=( -name 'Package.swift' )
+        exceptions=( -name 'Package.swift' -o -name 'Package@swift*.swift' )
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Motivation

Documentation is nice, and we can help support users by providing useful
clear docs.

Modifications

Add Docc to 5.6 and later builds
Make sure symbol references work
Add overview docs

Result

Nice rendering docs