### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Tests/StructuredFieldValuesTests/Fixtures.swift
+++ b/Tests/StructuredFieldValuesTests/Fixtures.swift
@@ -15,7 +15,7 @@ import Foundation
 
 enum FixturesLoader {
     private static var fixturesDirectory: URL {
-        let myURL = URL(fileURLWithPath: #file, isDirectory: false)
+        let myURL = URL(fileURLWithPath: #filePath, isDirectory: false)
         return URL(string: "../TestFixtures/", relativeTo: myURL)!.absoluteURL
     }
 


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath or #fileID depending on the situation
