### PR TITLE
Remove unneeded compiler guard.

### DIFF
--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -524,7 +524,6 @@ extension String {
         // We assume the string is previously validated, so the escapes are easily removed. See the doc comment for
         // `StrippingStringEscapesCollection` for more details on what we're doing here.
         let unescapedBytes = StrippingStringEscapesCollection(bytes, escapes: escapes)
-        #if canImport(Darwin)
         if #available(macOS 10.16, macCatalyst 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
             return String(unsafeUninitializedCapacity: unescapedBytes.count) { innerPtr in
                 let (_, endIndex) = innerPtr.initialize(from: unescapedBytes)
@@ -533,16 +532,6 @@ extension String {
         } else {
             return String(decoding: unescapedBytes, as: UTF8.self)
         }
-        #else
-        #if compiler(>=5.3)
-        return String(unsafeUninitializedCapacity: unescapedBytes.count) { innerPtr in
-            let (_, endIndex) = innerPtr.initialize(from: unescapedBytes)
-            return endIndex
-        }
-        #else
-        return String(decoding: unescapedBytes, as: UTF8.self)
-        #endif
-        #endif
     }
 }
 


### PR DESCRIPTION
Motivation:

We no longer support compilers older than 5.3 (or indeed older than 5.6), so we don't need compiler guards for old ones.

Modifications:

Remove fallback for old compilers.

Result:

Easier to understand code