### PR TITLE
Add support for Date type to StructuredFieldValues

### DIFF
--- a/Sources/StructuredFieldValues/Decoder/BareInnerListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/BareInnerListDecoder.swift
@@ -72,6 +72,9 @@ extension BareInnerListDecoder: UnkeyedDecodingContainer {
         } else if type is Decimal.Type {
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
+        } else if type is Date.Type {
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(Date.self) as! T
         } else {
             return try type.init(from: self.decoder)
         }

--- a/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
@@ -133,6 +133,14 @@ extension BareItemDecoder: SingleValueDecodingContainer {
         )
     }
 
+    func decode(_: Date.Type) throws -> Date {
+        guard case .date(let date) = self.item else {
+            throw StructuredHeaderError.invalidTypeForItem
+        }
+
+        return Date(timeIntervalSince1970: Double(date))
+    }
+
     func decodeNil() -> Bool {
         // Items are never nil.
         false
@@ -172,6 +180,8 @@ extension BareItemDecoder: SingleValueDecodingContainer {
             return try self.decode(Data.self) as! T
         case is Decimal.Type:
             return try self.decode(Decimal.self) as! T
+        case is Date.Type:
+            return try self.decode(Date.self) as! T
         default:
             throw StructuredHeaderError.invalidTypeForItem
         }

--- a/Sources/StructuredFieldValues/Decoder/DictionaryKeyedContainer.swift
+++ b/Sources/StructuredFieldValues/Decoder/DictionaryKeyedContainer.swift
@@ -55,6 +55,9 @@ extension DictionaryKeyedContainer: KeyedDecodingContainerProtocol {
         } else if type is Decimal.Type {
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
+        } else if type is Date.Type {
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(Date.self) as! T
         } else {
             return try type.init(from: self.decoder)
         }

--- a/Sources/StructuredFieldValues/Decoder/KeyedInnerListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/KeyedInnerListDecoder.swift
@@ -60,6 +60,9 @@ extension KeyedInnerListDecoder: KeyedDecodingContainerProtocol {
         } else if type is Decimal.Type {
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
+        } else if type is Date.Type {
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(Date.self) as! T
         } else {
             return try type.init(from: self.decoder)
         }

--- a/Sources/StructuredFieldValues/Decoder/KeyedItemDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/KeyedItemDecoder.swift
@@ -60,6 +60,9 @@ extension KeyedItemDecoder: KeyedDecodingContainerProtocol {
         } else if type is Decimal.Type {
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
+        } else if type is Date.Type {
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(Date.self) as! T
         } else {
             return try type.init(from: self.decoder)
         }

--- a/Sources/StructuredFieldValues/Decoder/KeyedTopLevelListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/KeyedTopLevelListDecoder.swift
@@ -60,6 +60,9 @@ extension KeyedTopLevelListDecoder: KeyedDecodingContainerProtocol {
         } else if type is Decimal.Type {
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
+        } else if type is Date.Type {
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(Date.self) as! T
         } else {
             return try type.init(from: self.decoder)
         }

--- a/Sources/StructuredFieldValues/Decoder/ParametersDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/ParametersDecoder.swift
@@ -55,6 +55,9 @@ extension ParametersDecoder: KeyedDecodingContainerProtocol {
         } else if type is Decimal.Type {
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
+        } else if type is Date.Type {
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(Date.self) as! T
         } else {
             return try type.init(from: self.decoder)
         }

--- a/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
@@ -117,6 +117,9 @@ extension StructuredFieldValueDecoder {
         } else if type is Decimal.Type {
             let container = try decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! StructuredField
+        } else if type is Date.Type {
+            let container = try decoder.singleValueContainer()
+            return try container.decode(Date.self) as! StructuredField
         } else {
             return try type.init(from: decoder)
         }

--- a/Sources/StructuredFieldValues/Decoder/TopLevelListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/TopLevelListDecoder.swift
@@ -72,6 +72,9 @@ extension TopLevelListDecoder: UnkeyedDecodingContainer {
         } else if type is Decimal.Type {
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
+        } else if type is Date.Type {
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(Date.self) as! T
         } else {
             return try type.init(from: self.decoder)
         }

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -160,6 +160,8 @@ class _StructuredFieldEncoder {
             try self.encode(value)
         } else if let value = data as? Decimal {
             try self.encode(value)
+        } else if let value = data as? Date {
+            try self.encode(value)
         } else {
             try data.encode(to: self)
         }
@@ -309,6 +311,11 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
         try self.currentStackEntry.storage.insertBareItem(.decimal(pd))
     }
 
+    func encode(_ data: Date) throws {
+        let date = Int(data.timeIntervalSince1970)
+        try self.currentStackEntry.storage.insertBareItem(.date(date))
+    }
+
     func encode<T>(_ value: T) throws where T: Encodable {
         switch value {
         case let value as UInt8:
@@ -342,6 +349,8 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
         case let value as Data:
             try self.encode(value)
         case let value as Decimal:
+            try self.encode(value)
+        case let value as Date:
             try self.encode(value)
         default:
             throw StructuredHeaderError.invalidTypeForItem
@@ -466,6 +475,11 @@ extension _StructuredFieldEncoder {
         try self.currentStackEntry.storage.appendBareItem(.decimal(pd))
     }
 
+    func append(_ value: Date) throws {
+        let date = Int(value.timeIntervalSince1970)
+        try self.currentStackEntry.storage.appendBareItem(.date(date))
+    }
+
     func append<T>(_ value: T) throws where T: Encodable {
         switch value {
         case let value as UInt8:
@@ -499,6 +513,8 @@ extension _StructuredFieldEncoder {
         case let value as Data:
             try self.append(value)
         case let value as Decimal:
+            try self.append(value)
+        case let value as Date:
             try self.append(value)
         default:
             // Some other codable type.
@@ -636,6 +652,12 @@ extension _StructuredFieldEncoder {
         try self.currentStackEntry.storage.insertBareItem(.decimal(pd), atKey: key)
     }
 
+    func encode(_ value: Date, forKey key: String) throws {
+        let key = self.sanitizeKey(key)
+        let date = Int(value.timeIntervalSince1970)
+        try self.currentStackEntry.storage.insertBareItem(.date(date), atKey: key)
+    }
+
     func encode<T>(_ value: T, forKey key: String) throws where T: Encodable {
         let key = self.sanitizeKey(key)
 
@@ -671,6 +693,8 @@ extension _StructuredFieldEncoder {
         case let value as Data:
             try self.encode(value, forKey: key)
         case let value as Decimal:
+            try self.encode(value, forKey: key)
+        case let value as Date:
             try self.encode(value, forKey: key)
         default:
             // Ok, we don't know what this is. This can only happen for a dictionary, or

--- a/Tests/StructuredFieldValuesTests/StructuredFieldDecoderTests.swift
+++ b/Tests/StructuredFieldValuesTests/StructuredFieldDecoderTests.swift
@@ -494,7 +494,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
     func testDecodingDateAsTopLevelData() throws {
         let headerField = "@4294967296"
         XCTAssertEqual(
-            ItemField(Date(timeIntervalSince1970: 4294967296)),
+            ItemField(Date(timeIntervalSince1970: 4_294_967_296)),
             try StructuredFieldValueDecoder().decode(from: Array(headerField.utf8))
         )
     }
@@ -511,7 +511,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
 
         XCTAssertEqual(
             Item(
-                item: Date(timeIntervalSince1970: 4294967296),
+                item: Date(timeIntervalSince1970: 4_294_967_296),
                 parameters: [:]
             ),
             try StructuredFieldValueDecoder().decode(
@@ -521,7 +521,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            Item(item: Date(timeIntervalSince1970: 4294967296), parameters: ["q": 0.8]),
+            Item(item: Date(timeIntervalSince1970: 4_294_967_296), parameters: ["q": 0.8]),
             try StructuredFieldValueDecoder().decode(
                 Item.self,
                 from: Array(headerFieldParameters.utf8)
@@ -538,7 +538,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
 
         let headerField = "1;q=@4294967296"
         XCTAssertEqual(
-            Item(item: 1, parameters: ["q": Date(timeIntervalSince1970: 4294967296)]),
+            Item(item: 1, parameters: ["q": Date(timeIntervalSince1970: 4_294_967_296)]),
             try StructuredFieldValueDecoder().decode(Item.self, from: Array(headerField.utf8))
         )
     }
@@ -547,7 +547,10 @@ final class StructuredFieldDecoderTests: XCTestCase {
         let headerField = "@4294967296, @-1659578233"
         XCTAssertEqual(
             List(
-                [Date(timeIntervalSince1970: 4294967296), Date(timeIntervalSince1970: -1659578233)]
+                [
+                    Date(timeIntervalSince1970: 4_294_967_296),
+                    Date(timeIntervalSince1970: -1_659_578_233)
+                ]
             ),
             try StructuredFieldValueDecoder().decode(from: Array(headerField.utf8))
         )
@@ -556,13 +559,15 @@ final class StructuredFieldDecoderTests: XCTestCase {
     func testDecodingDateInInnerListRaw() throws {
         let headerField = "(@4294967296 @-1659578233), (@4294967296 @-1659578233)"
         XCTAssertEqual(
-            List(Array(
-                repeating: [
-                    Date(timeIntervalSince1970: 4294967296),
-                    Date(timeIntervalSince1970: -1659578233)
-                ],
-                count: 2
-            )),
+            List(
+                Array(
+                    repeating: [
+                        Date(timeIntervalSince1970: 4_294_967_296),
+                        Date(timeIntervalSince1970: -1_659_578_233)
+                    ],
+                    count: 2
+                )
+            ),
             try StructuredFieldValueDecoder().decode(from: Array(headerField.utf8))
         )
     }
@@ -578,8 +583,8 @@ final class StructuredFieldDecoderTests: XCTestCase {
                 Array(
                     repeating: ListField(
                         items: [
-                            Date(timeIntervalSince1970: 4294967296),
-                            Date(timeIntervalSince1970: -1659578233)
+                            Date(timeIntervalSince1970: 4_294_967_296),
+                            Date(timeIntervalSince1970: -1_659_578_233)
                         ],
                         parameters: ["foo": true]
                     ),
@@ -600,8 +605,8 @@ final class StructuredFieldDecoderTests: XCTestCase {
         let headerField = "bin=@4294967296, box=@-1659578233"
         XCTAssertEqual(
             DictionaryField(
-                bin: Date(timeIntervalSince1970: 4294967296),
-                box: Date(timeIntervalSince1970: -1659578233)
+                bin: Date(timeIntervalSince1970: 4_294_967_296),
+                box: Date(timeIntervalSince1970: -1_659_578_233)
             ),
             try StructuredFieldValueDecoder().decode(from: Array(headerField.utf8))
         )

--- a/Tests/StructuredFieldValuesTests/StructuredFieldDecoderTests.swift
+++ b/Tests/StructuredFieldValuesTests/StructuredFieldDecoderTests.swift
@@ -549,7 +549,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
             List(
                 [
                     Date(timeIntervalSince1970: 4_294_967_296),
-                    Date(timeIntervalSince1970: -1_659_578_233)
+                    Date(timeIntervalSince1970: -1_659_578_233),
                 ]
             ),
             try StructuredFieldValueDecoder().decode(from: Array(headerField.utf8))
@@ -563,7 +563,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
                 Array(
                     repeating: [
                         Date(timeIntervalSince1970: 4_294_967_296),
-                        Date(timeIntervalSince1970: -1_659_578_233)
+                        Date(timeIntervalSince1970: -1_659_578_233),
                     ],
                     count: 2
                 )
@@ -584,7 +584,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
                     repeating: ListField(
                         items: [
                             Date(timeIntervalSince1970: 4_294_967_296),
-                            Date(timeIntervalSince1970: -1_659_578_233)
+                            Date(timeIntervalSince1970: -1_659_578_233),
                         ],
                         parameters: ["foo": true]
                     ),

--- a/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
+++ b/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
@@ -43,6 +43,10 @@ final class StructuredFieldEncoderTests: XCTestCase {
 
         // Binary Data
         XCTAssertEqual(Array(":AQIDBA==:".utf8), try encoder.encode(ItemField(Data([1, 2, 3, 4]))))
+
+        // Date
+        XCTAssertEqual(Array("@4294967296".utf8), try encoder.encode(ItemField(Date(timeIntervalSince1970: 4294967296))))
+        XCTAssertEqual(Array("@-1659578233".utf8), try encoder.encode(ItemField(Date(timeIntervalSince1970: -1659578233))))
     }
 
     func testEncodeKeyedItemHeader() throws {
@@ -95,6 +99,22 @@ final class StructuredFieldEncoderTests: XCTestCase {
         XCTAssertEqual(
             Array(":AQIDBA==:".utf8),
             try encoder.encode(KeyedItem(item: Data([1, 2, 3, 4]), parameters: [:]))
+        )
+
+        // Date
+        XCTAssertEqual(
+            Array("@4294967296;x".utf8),
+            try encoder.encode(KeyedItem(
+                item: Date(timeIntervalSince1970: 4294967296),
+                parameters: ["x": true]
+            ))
+        )
+        XCTAssertEqual(
+            Array("@-1659578233".utf8),
+            try encoder.encode(KeyedItem(
+                item: Date(timeIntervalSince1970: -1659578233),
+                parameters: [:]
+            ))
         )
     }
 
@@ -188,6 +208,14 @@ final class StructuredFieldEncoderTests: XCTestCase {
         XCTAssertEqual(
             Array(":AQIDBA==:, :BQYHCA==:".utf8),
             try encoder.encode(List([Data([1, 2, 3, 4]), Data([5, 6, 7, 8])]))
+        )
+
+        // Date
+        XCTAssertEqual(
+            Array("@4294967296, @-1659578233".utf8),
+            try encoder.encode(List(
+                [Date(timeIntervalSince1970: 4294967296), Date(timeIntervalSince1970: -1659578233)]
+            ))
         )
     }
 

--- a/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
+++ b/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
@@ -45,8 +45,14 @@ final class StructuredFieldEncoderTests: XCTestCase {
         XCTAssertEqual(Array(":AQIDBA==:".utf8), try encoder.encode(ItemField(Data([1, 2, 3, 4]))))
 
         // Date
-        XCTAssertEqual(Array("@4294967296".utf8), try encoder.encode(ItemField(Date(timeIntervalSince1970: 4294967296))))
-        XCTAssertEqual(Array("@-1659578233".utf8), try encoder.encode(ItemField(Date(timeIntervalSince1970: -1659578233))))
+        XCTAssertEqual(
+            Array("@4294967296".utf8),
+            try encoder.encode(ItemField(Date(timeIntervalSince1970: 4_294_967_296)))
+        )
+        XCTAssertEqual(
+            Array("@-1659578233".utf8),
+            try encoder.encode(ItemField(Date(timeIntervalSince1970: -1_659_578_233)))
+        )
     }
 
     func testEncodeKeyedItemHeader() throws {
@@ -104,17 +110,21 @@ final class StructuredFieldEncoderTests: XCTestCase {
         // Date
         XCTAssertEqual(
             Array("@4294967296;x".utf8),
-            try encoder.encode(KeyedItem(
-                item: Date(timeIntervalSince1970: 4294967296),
-                parameters: ["x": true]
-            ))
+            try encoder.encode(
+                KeyedItem(
+                    item: Date(timeIntervalSince1970: 4_294_967_296),
+                    parameters: ["x": true]
+                )
+            )
         )
         XCTAssertEqual(
             Array("@-1659578233".utf8),
-            try encoder.encode(KeyedItem(
-                item: Date(timeIntervalSince1970: -1659578233),
-                parameters: [:]
-            ))
+            try encoder.encode(
+                KeyedItem(
+                    item: Date(timeIntervalSince1970: -1_659_578_233),
+                    parameters: [:]
+                )
+            )
         )
     }
 
@@ -213,9 +223,14 @@ final class StructuredFieldEncoderTests: XCTestCase {
         // Date
         XCTAssertEqual(
             Array("@4294967296, @-1659578233".utf8),
-            try encoder.encode(List(
-                [Date(timeIntervalSince1970: 4294967296), Date(timeIntervalSince1970: -1659578233)]
-            ))
+            try encoder.encode(
+                List(
+                    [
+                        Date(timeIntervalSince1970: 4_294_967_296),
+                        Date(timeIntervalSince1970: -1_659_578_233)
+                    ]
+                )
+            )
         )
     }
 

--- a/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
+++ b/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
@@ -227,7 +227,7 @@ final class StructuredFieldEncoderTests: XCTestCase {
                 List(
                     [
                         Date(timeIntervalSince1970: 4_294_967_296),
-                        Date(timeIntervalSince1970: -1_659_578_233)
+                        Date(timeIntervalSince1970: -1_659_578_233),
                     ]
                 )
             )


### PR DESCRIPTION
Motivation:

The parser and serializer for the Date type has been implemented. The high-level encoder and decoder should follow.

Modifications:

- Implement the encoder and decoder for Date.

Result:

The StructuredFieldValues module will support the Date type.