### PR TITLE
Integer serialization fix for 32 bit platform compatibility

### DIFF
--- a/Sources/RawStructuredFieldValues/ComponentTypes.swift
+++ b/Sources/RawStructuredFieldValues/ComponentTypes.swift
@@ -94,7 +94,7 @@ extension BareItem {
             self = .bool(b)
 
         case .integer(let i):
-            self = .integer(i)
+            self = .integer(Int(i))
 
         case .decimal(let d):
             self = .decimal(d)
@@ -126,7 +126,7 @@ public enum RFC9651BareItem: Sendable {
     case bool(Bool)
 
     /// An integer item.
-    case integer(Int)
+    case integer(Int64)
 
     /// A decimal item.
     case decimal(PseudoDecimal)
@@ -142,7 +142,7 @@ public enum RFC9651BareItem: Sendable {
     case token(String)
 
     /// A date item.
-    case date(Int)
+    case date(Int64)
 
     /// A display string item.
     case displayString(String)
@@ -155,7 +155,7 @@ extension RFC9651BareItem: ExpressibleByBooleanLiteral {
 }
 
 extension RFC9651BareItem: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: Int) {
+    public init(integerLiteral value: Int64) {
         self = .integer(value)
     }
 }
@@ -184,7 +184,7 @@ extension RFC9651BareItem {
             self = .bool(b)
 
         case .integer(let i):
-            self = .integer(i)
+            self = .integer(Int64(i))
 
         case .decimal(let d):
             self = .decimal(d)

--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -232,7 +232,7 @@ extension StructuredFieldValueParser {
     }
 
     private mutating func _parseAnIntegerOrDecimal(isDate: Bool) throws -> RFC9651BareItem {
-        var sign = 1
+        var sign = Int64(1)
         var type = IntegerOrDecimal.integer
 
         if let first = self.underlyingData.first, first == asciiDash {
@@ -304,7 +304,7 @@ extension StructuredFieldValueParser {
         case .integer:
             // This intermediate string is sad, we should rewrite this manually to avoid it.
             // This force-unwrap is safe, as we have validated that all characters are ascii digits.
-            let baseInt = Int(String(decoding: integerBytes, as: UTF8.self), radix: 10)!
+            let baseInt = Int64(String(decoding: integerBytes, as: UTF8.self), radix: 10)!
             let resultingInt = baseInt * sign
 
             if isDate {

--- a/Sources/StructuredFieldValues/Decoder/BareInnerListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/BareInnerListDecoder.swift
@@ -66,16 +66,20 @@ extension BareInnerListDecoder: UnkeyedDecodingContainer {
             self.decoder.pop()
         }
 
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Data.self) as! T
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Date.self) as! T
-        } else {
+        case is DisplayString.Type:
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! T
+        default:
             return try type.init(from: self.decoder)
         }
     }

--- a/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
@@ -141,6 +141,14 @@ extension BareItemDecoder: SingleValueDecodingContainer {
         return Date(timeIntervalSince1970: Double(date))
     }
 
+    func decode(_: DisplayString.Type) throws -> DisplayString {
+        guard case .displayString(let string) = self.item else {
+            throw StructuredHeaderError.invalidTypeForItem
+        }
+
+        return DisplayString(string)
+    }
+
     func decodeNil() -> Bool {
         // Items are never nil.
         false
@@ -182,6 +190,8 @@ extension BareItemDecoder: SingleValueDecodingContainer {
             return try self.decode(Decimal.self) as! T
         case is Date.Type:
             return try self.decode(Date.self) as! T
+        case is DisplayString.Type:
+            return try self.decode(DisplayString.self) as! T
         default:
             throw StructuredHeaderError.invalidTypeForItem
         }

--- a/Sources/StructuredFieldValues/Decoder/DictionaryKeyedContainer.swift
+++ b/Sources/StructuredFieldValues/Decoder/DictionaryKeyedContainer.swift
@@ -49,16 +49,20 @@ extension DictionaryKeyedContainer: KeyedDecodingContainerProtocol {
             self.decoder.pop()
         }
 
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Data.self) as! T
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Date.self) as! T
-        } else {
+        case is DisplayString.Type:
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! T
+        default:
             return try type.init(from: self.decoder)
         }
     }

--- a/Sources/StructuredFieldValues/Decoder/KeyedInnerListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/KeyedInnerListDecoder.swift
@@ -54,16 +54,20 @@ extension KeyedInnerListDecoder: KeyedDecodingContainerProtocol {
             self.decoder.pop()
         }
 
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Data.self) as! T
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Date.self) as! T
-        } else {
+        case is DisplayString.Type:
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! T
+        default:
             return try type.init(from: self.decoder)
         }
     }

--- a/Sources/StructuredFieldValues/Decoder/KeyedItemDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/KeyedItemDecoder.swift
@@ -54,16 +54,20 @@ extension KeyedItemDecoder: KeyedDecodingContainerProtocol {
             self.decoder.pop()
         }
 
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Data.self) as! T
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Date.self) as! T
-        } else {
+        case is DisplayString.Type:
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! T
+        default:
             return try type.init(from: self.decoder)
         }
     }

--- a/Sources/StructuredFieldValues/Decoder/KeyedTopLevelListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/KeyedTopLevelListDecoder.swift
@@ -54,16 +54,20 @@ extension KeyedTopLevelListDecoder: KeyedDecodingContainerProtocol {
             self.decoder.pop()
         }
 
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Data.self) as! T
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Date.self) as! T
-        } else {
+        case is DisplayString.Type:
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! T
+        default:
             return try type.init(from: self.decoder)
         }
     }

--- a/Sources/StructuredFieldValues/Decoder/ParametersDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/ParametersDecoder.swift
@@ -49,16 +49,20 @@ extension ParametersDecoder: KeyedDecodingContainerProtocol {
             self.decoder.pop()
         }
 
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Data.self) as! T
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Date.self) as! T
-        } else {
+        case is DisplayString.Type:
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! T
+        default:
             return try type.init(from: self.decoder)
         }
     }

--- a/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/StructuredFieldValueDecoder.swift
@@ -111,16 +111,20 @@ extension StructuredFieldValueDecoder {
 
         // An escape hatch here for top-level data: if we don't do this, it'll ask for
         // an unkeyed container and get very confused.
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try decoder.singleValueContainer()
             return try container.decode(Data.self) as! StructuredField
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! StructuredField
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try decoder.singleValueContainer()
             return try container.decode(Date.self) as! StructuredField
-        } else {
+        case is DisplayString.Type:
+            let container = try decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! StructuredField
+        default:
             return try type.init(from: decoder)
         }
     }

--- a/Sources/StructuredFieldValues/Decoder/TopLevelListDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/TopLevelListDecoder.swift
@@ -66,16 +66,20 @@ extension TopLevelListDecoder: UnkeyedDecodingContainer {
             self.decoder.pop()
         }
 
-        if type is Data.Type {
+        switch type {
+        case is Data.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Data.self) as! T
-        } else if type is Decimal.Type {
+        case is Decimal.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Decimal.self) as! T
-        } else if type is Date.Type {
+        case is Date.Type:
             let container = try self.decoder.singleValueContainer()
             return try container.decode(Date.self) as! T
-        } else {
+        case is DisplayString.Type:
+            let container = try self.decoder.singleValueContainer()
+            return try container.decode(DisplayString.self) as! T
+        default:
             return try type.init(from: self.decoder)
         }
     }

--- a/Sources/StructuredFieldValues/DisplayString.swift
+++ b/Sources/StructuredFieldValues/DisplayString.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A type that represents the Display String Structured Type.
+public struct DisplayString: Codable, Equatable {
+    /// The value of this Display String.
+    public private(set) var description: String
+
+    /// Initializes a new Display String.
+    ///
+    /// - parameters:
+    ///   - description: The value of this Display String.
+    public init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -313,7 +313,7 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
     }
 
     func encode(_ data: Date) throws {
-        let date = Int(data.timeIntervalSince1970)
+        let date = Int64(data.timeIntervalSince1970)
         try self.currentStackEntry.storage.insertBareItem(.date(date))
     }
 
@@ -371,7 +371,7 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
     }
 
     private func _encodeFixedWidthInteger<T: FixedWidthInteger>(_ value: T) throws {
-        guard let base = Int(exactly: value) else {
+        guard let base = Int64(exactly: value) else {
             throw StructuredHeaderError.integerOutOfRange
         }
         try self.currentStackEntry.storage.insertBareItem(.integer(base))
@@ -483,7 +483,7 @@ extension _StructuredFieldEncoder {
     }
 
     func append(_ value: Date) throws {
-        let date = Int(value.timeIntervalSince1970)
+        let date = Int64(value.timeIntervalSince1970)
         try self.currentStackEntry.storage.appendBareItem(.date(date))
     }
 
@@ -562,7 +562,7 @@ extension _StructuredFieldEncoder {
     }
 
     private func _appendFixedWidthInteger<T: FixedWidthInteger>(_ value: T) throws {
-        guard let base = Int(exactly: value) else {
+        guard let base = Int64(exactly: value) else {
             throw StructuredHeaderError.integerOutOfRange
         }
         try self.currentStackEntry.storage.appendBareItem(.integer(base))
@@ -667,7 +667,7 @@ extension _StructuredFieldEncoder {
 
     func encode(_ value: Date, forKey key: String) throws {
         let key = self.sanitizeKey(key)
-        let date = Int(value.timeIntervalSince1970)
+        let date = Int64(value.timeIntervalSince1970)
         try self.currentStackEntry.storage.insertBareItem(.date(date), atKey: key)
     }
 
@@ -789,7 +789,7 @@ extension _StructuredFieldEncoder {
     }
 
     private func _encodeFixedWidthInteger<T: FixedWidthInteger>(_ value: T, forKey key: String) throws {
-        guard let base = Int(exactly: value) else {
+        guard let base = Int64(exactly: value) else {
             throw StructuredHeaderError.integerOutOfRange
         }
         try self.currentStackEntry.storage.insertBareItem(.integer(base), atKey: key)

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -150,19 +150,20 @@ class _StructuredFieldEncoder {
     fileprivate func encodeItemField<StructuredField: Encodable>(_ data: StructuredField) throws -> [UInt8] {
         self.push(key: .init(stringValue: ""), newStorage: .itemHeader)
 
-        // There's an awkward special hook here: if the outer type is `Data` or `Decimal`,
-        // we skip the regular encoding path. This is because otherwise `Data` will
-        // ask for an unkeyed container and `Decimal` for a keyed one,
-        // and it all falls apart.
+        // There's an awkward special hook here: if the outer type is `Data`, `Decimal`, `Date` or
+        // `DisplayString`, we skip the regular encoding path.
         //
         // Everything else goes through the normal flow.
-        if let value = data as? Data {
-            try self.encode(value)
-        } else if let value = data as? Decimal {
-            try self.encode(value)
-        } else if let value = data as? Date {
-            try self.encode(value)
-        } else {
+        switch data {
+        case is Data:
+            try self.encode(data)
+        case is Decimal:
+            try self.encode(data)
+        case is Date:
+            try self.encode(data)
+        case is DisplayString:
+            try self.encode(data)
+        default:
             try data.encode(to: self)
         }
 
@@ -316,6 +317,10 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
         try self.currentStackEntry.storage.insertBareItem(.date(date))
     }
 
+    func encode(_ data: DisplayString) throws {
+        try self.currentStackEntry.storage.insertBareItem(.displayString(data.description))
+    }
+
     func encode<T>(_ value: T) throws where T: Encodable {
         switch value {
         case let value as UInt8:
@@ -351,6 +356,8 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
         case let value as Decimal:
             try self.encode(value)
         case let value as Date:
+            try self.encode(value)
+        case let value as DisplayString:
             try self.encode(value)
         default:
             throw StructuredHeaderError.invalidTypeForItem
@@ -480,6 +487,10 @@ extension _StructuredFieldEncoder {
         try self.currentStackEntry.storage.appendBareItem(.date(date))
     }
 
+    func append(_ value: DisplayString) throws {
+        try self.currentStackEntry.storage.appendBareItem(.displayString(value.description))
+    }
+
     func append<T>(_ value: T) throws where T: Encodable {
         switch value {
         case let value as UInt8:
@@ -515,6 +526,8 @@ extension _StructuredFieldEncoder {
         case let value as Decimal:
             try self.append(value)
         case let value as Date:
+            try self.append(value)
+        case let value as DisplayString:
             try self.append(value)
         default:
             // Some other codable type.
@@ -658,6 +671,12 @@ extension _StructuredFieldEncoder {
         try self.currentStackEntry.storage.insertBareItem(.date(date), atKey: key)
     }
 
+    func encode(_ value: DisplayString, forKey key: String) throws {
+        let key = self.sanitizeKey(key)
+        let displayString = value.description
+        try self.currentStackEntry.storage.insertBareItem(.displayString(displayString), atKey: key)
+    }
+
     func encode<T>(_ value: T, forKey key: String) throws where T: Encodable {
         let key = self.sanitizeKey(key)
 
@@ -695,6 +714,8 @@ extension _StructuredFieldEncoder {
         case let value as Decimal:
             try self.encode(value, forKey: key)
         case let value as Date:
+            try self.encode(value, forKey: key)
+        case let value as DisplayString:
             try self.encode(value, forKey: key)
         default:
             // Ok, we don't know what this is. This can only happen for a dictionary, or

--- a/Tests/StructuredFieldValuesTests/Fixtures.swift
+++ b/Tests/StructuredFieldValuesTests/Fixtures.swift
@@ -119,7 +119,7 @@ struct StructuredHeaderTestFixture: Decodable {
 enum JSONSchema: Decodable {
     case dictionary([String: JSONSchema])
     case array([JSONSchema])
-    case integer(Int)
+    case integer(Int64)
     case double(Double)
     case string(String)
     case bool(Bool)
@@ -130,7 +130,7 @@ enum JSONSchema: Decodable {
             self = .string(value)
         } else if let bool = try? container.decode(Bool.self) {
             self = .bool(bool)
-        } else if let value = try? container.decode(Int.self) {
+        } else if let value = try? container.decode(Int64.self) {
             self = .integer(value)
         } else if let value = try? container.decode(Double.self) {
             self = .double(value)

--- a/Tests/StructuredFieldValuesTests/StructuredFieldDecoderTests.swift
+++ b/Tests/StructuredFieldValuesTests/StructuredFieldDecoderTests.swift
@@ -89,7 +89,7 @@ struct ListyDictionaryField: StructuredFieldValue, Equatable {
 final class StructuredFieldDecoderTests: XCTestCase {
     func testSimpleCodableDecode() throws {
         let headerField =
-        "primary=bar;q=1.0, secondary=baz;q=0.5;fallback=last, acceptablejurisdictions=(AU;q=1.0 GB;q=0.9 FR);fallback=\"primary\""
+            "primary=bar;q=1.0, secondary=baz;q=0.5;fallback=last, acceptablejurisdictions=(AU;q=1.0 GB;q=0.9 FR);fallback=\"primary\""
         let parsed = try StructuredFieldValueDecoder().decode(ListyDictionaryField.self, from: Array(headerField.utf8))
         let expected = ListyDictionaryField(
             primary: .init(item: "bar", parameters: .init(q: 1, fallback: nil)),
@@ -115,7 +115,7 @@ final class StructuredFieldDecoderTests: XCTestCase {
             var acceptablejurisdictions: [String]
         }
         let headerField =
-        "primary=bar;q=1.0, secondary=baz;q=0.5;fallback=last, acceptablejurisdictions=(AU;q=1.0 GB;q=0.9 FR);fallback=\"primary\""
+            "primary=bar;q=1.0, secondary=baz;q=0.5;fallback=last, acceptablejurisdictions=(AU;q=1.0 GB;q=0.9 FR);fallback=\"primary\""
         let parsed = try StructuredFieldValueDecoder().decode(
             ListyDictionaryNoParams.self,
             from: Array(headerField.utf8)

--- a/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
+++ b/Tests/StructuredFieldValuesTests/StructuredFieldEncoderTests.swift
@@ -53,6 +53,12 @@ final class StructuredFieldEncoderTests: XCTestCase {
             Array("@-1659578233".utf8),
             try encoder.encode(ItemField(Date(timeIntervalSince1970: -1_659_578_233)))
         )
+
+        // Display String
+        XCTAssertEqual(
+            Array("%\"f%c3%bc%c3%bc\"".utf8),
+            try encoder.encode(ItemField(DisplayString("füü")))
+        )
     }
 
     func testEncodeKeyedItemHeader() throws {
@@ -125,6 +131,16 @@ final class StructuredFieldEncoderTests: XCTestCase {
                     parameters: [:]
                 )
             )
+        )
+
+        // Display String
+        XCTAssertEqual(
+            Array("%\"f%c3%bc%c3%bc\";x".utf8),
+            try encoder.encode(KeyedItem(item: DisplayString("füü"), parameters: ["x": true]))
+        )
+        XCTAssertEqual(
+            Array("%\"foo %22bar%22 \\ baz\"".utf8),
+            try encoder.encode(KeyedItem(item: DisplayString("foo \"bar\" \\ baz"), parameters: [:]))
         )
     }
 
@@ -231,6 +247,12 @@ final class StructuredFieldEncoderTests: XCTestCase {
                     ]
                 )
             )
+        )
+
+        // Display String
+        XCTAssertEqual(
+            Array("%\"f%c3%bc%c3%bc\", %\"foo %22bar%22 \\ baz\"".utf8),
+            try encoder.encode(List([DisplayString("füü"), DisplayString("foo \"bar\" \\ baz")]))
         )
     }
 


### PR DESCRIPTION
Motivation:

[RFC 9651](https://www.ietf.org/rfc/rfc9651.html) permits serializing an integer in the range of -999,999,999,999,999 to 999,999,999,999,999 inclusive ([Section 4.1.4-2.1.1](https://www.ietf.org/rfc/rfc9651.html#section-4.1.4-2.1.1)). As `RFC9651BareItem` takes values `integer` or `date` with an associated value of type `Int`, that range is implicitly more constrained on 32-bit platforms to a subset range of `-Int32.min` to `Int32.max` inclusive.

Modifications:

- Adjust `RFC9651BareItem` to take values `integer` or `date` with an associated value of type `Int64` instead, which is sufficient for the permitted range.

Result:

Compatibility for the Integer and Date Structured Types on 32-bit platforms.