### PR TITLE
Enable strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,3 +45,9 @@ let package = Package(
         ),
     ]
 )
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
+}

--- a/Sources/StructuredFieldValues/StructuredFieldValue.swift
+++ b/Sources/StructuredFieldValues/StructuredFieldValue.swift
@@ -22,7 +22,7 @@ public protocol StructuredFieldValue: Codable {
 }
 
 /// The kinds of header fields used in HTTP Structured Headers.
-public enum StructuredFieldType {
+public enum StructuredFieldType: Sendable {
     /// An item field consists of a single item, optionally with parameters.
     case item
 

--- a/Sources/sh-parser/main.swift
+++ b/Sources/sh-parser/main.swift
@@ -15,13 +15,13 @@
 import Foundation
 import RawStructuredFieldValues
 
-struct Flags: Sendable {
+struct Flags {
     var headerType: HeaderType
 
     init() {
         // Default to item
         self.headerType = .item
-        let arguments = CommandLine.arguments
+        let arguments = ProcessInfo.processInfo.arguments
 
         for argument in arguments.dropFirst() {
             switch argument {

--- a/Sources/sh-parser/main.swift
+++ b/Sources/sh-parser/main.swift
@@ -15,7 +15,7 @@
 import Foundation
 import RawStructuredFieldValues
 
-struct Flags {
+struct Flags: Sendable {
     var headerType: HeaderType
 
     init() {

--- a/Sources/sh-parser/main.swift
+++ b/Sources/sh-parser/main.swift
@@ -21,8 +21,9 @@ struct Flags {
     init() {
         // Default to item
         self.headerType = .item
+        let arguments = CommandLine.arguments
 
-        for argument in CommandLine.arguments.dropFirst() {
+        for argument in arguments.dropFirst() {
             switch argument {
             case "--dictionary":
                 self.headerType = .dictionary


### PR DESCRIPTION
Motivation:

To catch potential data races at build time.

Modifications:

- Enable strict concurrency in Package.swift.
- Add `Sendable` conformance to `StructuredFieldType`.
- Swap [concurrency-unsafe](https://github.com/swiftlang/swift/issues/66213) `CommandLine.arguments` for `ProcessInfo.processInfo.arguments`.

Result:

Strict concurrency adoption.