### PR TITLE
Update StructuredFieldValueParser to add missing visionOS guard

### DIFF
--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -527,7 +527,7 @@ extension StructuredFieldValueParser {
                 byteArray.append(octet)
             case asciiDquote:
                 #if compiler(>=6.0)
-                if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *) {
+                if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
                     let unicodeSequence = String(validating: byteArray, as: UTF8.self)
 
                     guard let unicodeSequence else {


### PR DESCRIPTION
Update StructuredFieldValueParser to add missing visionOS guard matching the guards on the called API. This was causing failures to compile for visionOS