### PR TITLE
Fixed sendability warnings when -require-explict-sendable flag is enabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,5 +27,5 @@ jobs:
         with:
             runner_pool: nightly
             build_scheme: swift-http-structured-headers-Package
-	    xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-      	    xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-            linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
     static-sdk:
         name: Static SDK
@@ -27,3 +27,5 @@ jobs:
         with:
             runner_pool: nightly
             build_scheme: swift-http-structured-headers-Package
+	    xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+      	    xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
 
     static-sdk:
         name: Static SDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,4 +35,4 @@ jobs:
             runner_pool: general
             build_scheme: swift-http-structured-headers-Package
             xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-      	    xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,10 +15,10 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
     cxx-interop:
         name: Cxx interop
@@ -34,3 +34,5 @@ jobs:
         with:
             runner_pool: general
             build_scheme: swift-http-structured-headers-Package
+	    xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+      	    xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,5 +34,5 @@ jobs:
         with:
             runner_pool: general
             build_scheme: swift-http-structured-headers-Package
-	    xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
       	    xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"

--- a/Sources/RawStructuredFieldValues/ComponentTypes.swift
+++ b/Sources/RawStructuredFieldValues/ComponentTypes.swift
@@ -276,7 +276,7 @@ extension BareInnerList: ExpressibleByArrayLiteral {
 
 // TODO: RangeReplaceableCollection I guess
 extension BareInnerList: RandomAccessCollection, MutableCollection {
-    public struct Index {
+    public struct Index: Sendable {
         fileprivate var baseIndex: Array<Item>.Index
 
         init(_ baseIndex: Array<Item>.Index) {

--- a/Sources/StructuredFieldValues/DisplayString.swift
+++ b/Sources/StructuredFieldValues/DisplayString.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that represents the Display String Structured Type.
-public struct DisplayString: RawRepresentable, Codable, Equatable, Hashable {
+public struct DisplayString: RawRepresentable, Codable, Equatable, Hashable, Sendable {
     public typealias RawValue = String
     public var rawValue: String
 


### PR DESCRIPTION
Fixed sendability warnings when -require-explict-sendable flag is enabled. Added -Xswiftc -Xfrontend to fix GA workflow.