### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,6 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/Sources/RawStructuredFieldValues/FieldParser.swift
+++ b/Sources/RawStructuredFieldValues/FieldParser.swift
@@ -526,7 +526,6 @@ extension StructuredFieldValueParser {
 
                 byteArray.append(octet)
             case asciiDquote:
-                #if compiler(>=6.0)
                 if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
                     let unicodeSequence = String(validating: byteArray, as: UTF8.self)
 
@@ -538,9 +537,6 @@ extension StructuredFieldValueParser {
                 } else {
                     return try _decodeDisplayString(byteArray: &byteArray)
                 }
-                #else
-                return try _decodeDisplayString(byteArray: &byteArray)
-                #endif
             default:
                 byteArray.append(char)
             }

--- a/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
+++ b/Sources/StructuredFieldValues/Decoder/BareItemDecoder.swift
@@ -62,7 +62,6 @@ extension BareItemDecoder: SingleValueDecodingContainer {
         try self._decodeFixedWidthInteger(type)
     }
 
-    #if compiler(>=6.0)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func decode(_ type: UInt128.Type) throws -> UInt128 {
         try self._decodeFixedWidthInteger(type)
@@ -72,7 +71,6 @@ extension BareItemDecoder: SingleValueDecodingContainer {
     func decode(_ type: Int128.Type) throws -> Int128 {
         try self._decodeFixedWidthInteger(type)
     }
-    #endif
 
     func decode(_ type: UInt.Type) throws -> UInt {
         try self._decodeFixedWidthInteger(type)

--- a/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
+++ b/Sources/StructuredFieldValues/Encoder/StructuredFieldValueEncoder.swift
@@ -263,12 +263,10 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
         try self._encodeFixedWidthInteger(value)
     }
 
-    #if compiler(>=6.0)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func encode(_ value: Int128) throws {
         try self._encodeFixedWidthInteger(value)
     }
-    #endif
 
     func encode(_ value: UInt) throws {
         try self._encodeFixedWidthInteger(value)
@@ -290,12 +288,10 @@ extension _StructuredFieldEncoder: SingleValueEncodingContainer {
         try self._encodeFixedWidthInteger(value)
     }
 
-    #if compiler(>=6.0)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func encode(_ value: UInt128) throws {
         try self._encodeFixedWidthInteger(value)
     }
-    #endif
 
     func encode(_ data: Data) throws {
         let encoded = data.base64EncodedString()


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
