### PR TITLE
Migrate macOS build argument overrides to Swift version inputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,9 @@ jobs:
         with:
             runner_pool: nightly
             build_scheme: swift-http-structured-headers-Package
-            xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-            xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            swift_6_1_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            swift_6_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            swift_6_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
 
     release-builds:
         name: Release builds

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,8 +38,9 @@ jobs:
         with:
             runner_pool: general
             build_scheme: swift-http-structured-headers-Package
-            xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-            xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            swift_6_1_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            swift_6_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            swift_6_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
 
     release-builds:
         name: Release builds


### PR DESCRIPTION
Motivation

* The shared `macos_tests.yml` workflow no longer accepts
  `xcode_16_2_build_arguments_override` and the `xcode_16_3` input is a
  no-op. Passing the removed input causes CI to fail.
* Older Xcodes are being removed from the runners; Swift version inputs
  are the replacement.

Modifications

* Replace `xcode_16_2/16_3_build_arguments_override` with
  `swift_6_1/6_2/6_3_build_arguments_override` carrying the same
  `-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable` value.

Result

* macOS CI passes again using the Swift version inputs.
